### PR TITLE
ブログ一覧側のいいね

### DIFF
--- a/handlers/blogs_likes/blogs_likes.go
+++ b/handlers/blogs_likes/blogs_likes.go
@@ -7,6 +7,40 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// FetchBlogLikesByVisitId - 訪問IDに紐づくブログいいねデータを取得するハンドラ
+func (h *BlogLikeHandler) FetchBlogLikesByVisitId(c echo.Context) error {
+	utils.LogInfo(c, "Fetching blog likes by visit id...")
+
+	// クッキーからJWTトークンを取得
+	cookieValue, err := h.CookieUtils.GetAuthCookieValue(c, "visit-id-token")
+	if err != nil {
+		utils.LogError(c, "Error getting visit id token: "+err.Error())
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "Failed to get visit id token",
+		})
+	}
+	// JWTトークンを解析して訪問IDを取得
+	visitId, err := h.CookieUtils.GetVisitIdFromToken(c, cookieValue)
+	if err != nil {
+		utils.LogError(c, "Error getting visit id: "+err.Error())
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "Failed to get visit id",
+		})
+	}
+
+	// VisitIDに紐づくいいねデータを取得
+	blogLikesData, err := h.BlogLikeService.FetchBlogLikesByVisitId(visitId)
+	if err != nil {
+		utils.LogError(c, "Error fetching blog likes by visit id: "+err.Error())
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "Error fetching blog likes by visit id",
+		})
+	}
+
+	utils.LogInfo(c, "Blog likes fetched successfully")
+	return c.JSON(http.StatusOK, blogLikesData)
+}
+
 // GenerateVisitorId -　訪問者IDを生成するハンドラ
 func (h *BlogLikeHandler) GenerateVisitorId(c echo.Context) error {
 	utils.LogInfo(c, "Generating visitor id...")

--- a/handlers/blogs_likes/blogs_likes_FetchBlogLikesByVisitId_test.go
+++ b/handlers/blogs_likes/blogs_likes_FetchBlogLikesByVisitId_test.go
@@ -1,0 +1,149 @@
+package handlers_blogs_likes
+
+import (
+	"backend/models"
+	services_blogs_likes "backend/services/blogs_likes"
+	utils_cookie "backend/utils/cookie"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandler_FetchBlogLikesByVisitId(t *testing.T) {
+	// Echoのセットアップ
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/blog-likes", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	// モックサービスをインスタンス化
+	mockCookieUtils := new(utils_cookie.MockCookieUtils)
+	mockService := new(services_blogs_likes.MockBlogLikeService)
+	handler := NewBlogLikeHandler(mockService, mockCookieUtils)
+
+	// モックデータの設定
+	mockBlog := []models.BlogLikeData{
+		{
+			ID:      "1",
+			BlogId:  "1",
+			VisitId: "valid-visit-id",
+		},
+		{
+			ID:      "2",
+			BlogId:  "2",
+			VisitId: "valid-visit-id",
+		},
+	}
+	mockService.On("FetchBlogLikesByVisitId", "valid-visit-id").Return(mockBlog, nil)
+
+	// クッキーのモックを設定
+	SetMockBlogCookies(c, req, mockCookieUtils)
+
+	// ハンドラーを実行
+	err := handler.FetchBlogLikesByVisitId(c)
+	assert.NoError(t, err)
+
+	// ステータスコードとレスポンス内容の確認
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "valid-visit-id")
+
+	// モックが期待通りに呼び出されたかを確認
+	mockService.AssertExpectations(t)
+}
+
+func TestHandler_FetchBlogLikesByVisitId_NoCookie(t *testing.T) {
+	// Echoのセットアップ
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/blog-likes", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	// モックサービスをインスタンス化
+	mockCookieUtils := new(utils_cookie.MockCookieUtils)
+	mockService := new(services_blogs_likes.MockBlogLikeService)
+	handler := NewBlogLikeHandler(mockService, mockCookieUtils)
+
+	// モックを設定
+	mockCookieUtils.On("GetAuthCookieValue", c, "visit-id-token").Return("", errors.New("no cookie"))
+
+	// ハンドラーを実行
+	err := handler.FetchBlogLikesByVisitId(c)
+	assert.NoError(t, err)
+
+	// ステータスコードとレスポンス内容の確認
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Failed to get visit id token")
+
+	// モックが期待通りに呼び出されたかを確認
+	mockService.AssertNotCalled(t, "FetchBlogLikesByVisitId", "valid-visit-id")
+}
+
+func TestHandler_FetchBlogLikesByVisitId_NoVisitId(t *testing.T) {
+	// Echoのセットアップ
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/blog-likes", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	// リクエストにクッキーを追加
+	token := "mocked-token"
+	cookie := &http.Cookie{
+		Name:  "visit-id-token",
+		Value: token,
+		Path:  "/",
+	}
+	req.AddCookie(cookie)
+
+	// モックサービスをインスタンス化
+	mockCookieUtils := new(utils_cookie.MockCookieUtils)
+	mockService := new(services_blogs_likes.MockBlogLikeService)
+	handler := NewBlogLikeHandler(mockService, mockCookieUtils)
+
+	// モックを設定
+	mockCookieUtils.On("GetAuthCookieValue", c, "visit-id-token").Return("mocked-token", nil)
+	mockCookieUtils.On("GetVisitIdFromToken", c, token).Return("", errors.New("no visit id"))
+
+	// ハンドラーを実行
+	err := handler.FetchBlogLikesByVisitId(c)
+	assert.NoError(t, err)
+
+	// ステータスコードとレスポンス内容の確認
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Failed to get visit id")
+
+	// モックが期待通りに呼び出されたかを確認
+	mockService.AssertNotCalled(t, "FetchBlogLikesByVisitId", "valid-visit-id")
+}
+
+func TestHandler_FetchBlogLikesByVisitId_NotData(t *testing.T) {
+	// Echoのセットアップ
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/blog-likes", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	// モックサービスをインスタンス化
+	mockCookieUtils := new(utils_cookie.MockCookieUtils)
+	mockService := new(services_blogs_likes.MockBlogLikeService)
+	handler := NewBlogLikeHandler(mockService, mockCookieUtils)
+
+	// モックデータの設定
+	mockService.On("FetchBlogLikesByVisitId", "valid-visit-id").Return(nil, errors.New("no data"))
+
+	// クッキーのモックを設定
+	SetMockBlogCookies(c, req, mockCookieUtils)
+
+	// ハンドラーを実行
+	err := handler.FetchBlogLikesByVisitId(c)
+	assert.NoError(t, err)
+
+	// ステータスコードとレスポンス内容の確認
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Error fetching blog likes by visit id")
+
+	// モックが期待通りに呼び出されたかを確認
+	mockService.AssertExpectations(t)
+}

--- a/handlers/blogs_likes/blogs_likes_cookie_mock.go
+++ b/handlers/blogs_likes/blogs_likes_cookie_mock.go
@@ -1,0 +1,27 @@
+package handlers_blogs_likes
+
+import (
+	utils_cookie "backend/utils/cookie"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// SetMockBlogCookies は、ブログ関連のクッキーを設定します
+func SetMockBlogCookies(c echo.Context, req *http.Request, mockCookieUtils *utils_cookie.MockCookieUtils) {
+	// JWT の署名キーを設定し、正しいトークンを生成
+	token := "mocked-token"
+	validVisitId := "valid-visit-id"
+
+	// リクエストにクッキーを追加
+	cookie := &http.Cookie{
+		Name:  "visit-id-token",
+		Value: token,
+		Path:  "/",
+	}
+	req.AddCookie(cookie)
+
+	// モックの振る舞いを設定
+	mockCookieUtils.On("GetAuthCookieValue", c, "visit-id-token").Return(token, nil)
+	mockCookieUtils.On("GetVisitIdFromToken", c, token).Return(validVisitId, nil)
+}

--- a/repositories/blogs_likes/blogs_likes.go
+++ b/repositories/blogs_likes/blogs_likes.go
@@ -6,6 +6,42 @@ import (
 	"log"
 )
 
+// VisitIdによっていいねデータを取得
+func (r *BlogLikeRepositoryImpl) FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikeData, error) {
+	log.Println("FetchBlogLikesByVisitId start...")
+
+	// データベースからいいねデータを取得
+	query := `
+		SELECT id, blog_id, visit_id, created_at, updated_at
+		FROM blogs_likes
+		WHERE visit_id = $1
+	`
+	// クエリを実行し、いいねデータを取得
+	rows, err := supabase.Pool.Query(supabase.Ctx, query, visitId)
+	if err != nil {
+		log.Printf("Failed to fetch blog likes by visit id: %v", err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	// いいねデータを格納するスライスを作成
+	var blogLikes []models.BlogLikeData
+
+	// いいねデータをスキャンしてスライスに追加
+	for rows.Next() {
+		var blogLike = models.BlogLikeData{}
+		err := rows.Scan(&blogLike.ID, &blogLike.BlogId, &blogLike.VisitId, &blogLike.CreatedAt, &blogLike.UpdatedAt)
+		if err != nil {
+			log.Printf("Failed to scan blog like: %v", err)
+			return nil, err
+		}
+		blogLikes = append(blogLikes, blogLike)
+	}
+
+	log.Printf("Fetched blog likes by visit id: %v", blogLikes)
+	return blogLikes, nil
+}
+
 // いいね存在するか確認
 func (r *BlogLikeRepositoryImpl) IsBlogLiked(blogId, visitId string) (bool, error) {
 	log.Println("IsBlogLiked start...")

--- a/repositories/blogs_likes/blogs_likes_impl.go
+++ b/repositories/blogs_likes/blogs_likes_impl.go
@@ -4,6 +4,7 @@ import "backend/models"
 
 // BlogLikeRepositoryインターフェース
 type BlogLikeRepository interface {
+	FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikeData, error)
 	IsBlogLiked(blogId, visitId string) (bool, error)
 	CreateBlogLike(blogId, visitId string) (*models.BlogLikeData, error)
 	DeleteBlogLike(blogId, visitId string) error

--- a/repositories/blogs_likes/blogs_likes_mock.go
+++ b/repositories/blogs_likes/blogs_likes_mock.go
@@ -10,6 +10,14 @@ type MockBlogLikeRepository struct {
 	mock.Mock
 }
 
+func (m *MockBlogLikeRepository) FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikeData, error) {
+	args := m.Called(visitId)
+	if args.Get(0) != nil {
+		return args.Get(0).([]models.BlogLikeData), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func (m *MockBlogLikeRepository) IsBlogLiked(blogId, visitId string) (bool, error) {
 	args := m.Called(blogId, visitId)
 	return args.Bool(0), args.Error(1)

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -78,6 +78,7 @@ func SetupRoutes(e *echo.Echo) {
 		// ブログいいね関連のエンドポイント
 		blogLikes := api.Group("/blog-likes")
 		{
+			blogLikes.GET("", BlogLikeHandler.FetchBlogLikesByVisitId)
 			blogLikes.GET("/generate-visit-id", BlogLikeHandler.GenerateVisitorId)
 			blogLikes.GET("/is-liked/:blogId", BlogLikeHandler.IsBlogLiked)
 			blogLikes.POST("/create/:blogId", BlogLikeHandler.CreateBlogLike)

--- a/services/blogs_likes/blogs_likes.go
+++ b/services/blogs_likes/blogs_likes.go
@@ -6,6 +6,27 @@ import (
 	"log"
 )
 
+// VisitIdに紐づくいいねデータを取得
+func (s *BlogLikeServiceImpl) FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikeData, error) {
+	log.Println("FetchBlogLikesByVisitId start...")
+
+	// バリデーション
+	if visitId == "" {
+		log.Println("VisitId is empty")
+		return nil, errors.New("visitId is empty")
+	}
+
+	log.Println("validation passed")
+
+	// いいねデータを取得
+	blogLikes, err := s.BlogLikeRepository.FetchBlogLikesByVisitId(visitId)
+	if err != nil {
+		return nil, err
+	}
+
+	return blogLikes, nil
+}
+
 // いいね存在するか確認
 func (s *BlogLikeServiceImpl) IsBlogLiked(blogId, visitId string) (bool, error) {
 	log.Println("IsBlogLiked start...")

--- a/services/blogs_likes/blogs_likes_FetchBlogLikesByVisitId_test.go
+++ b/services/blogs_likes/blogs_likes_FetchBlogLikesByVisitId_test.go
@@ -1,0 +1,79 @@
+package services_blogs_likes
+
+import (
+	"backend/models"
+	repositories_blogs_likes "backend/repositories/blogs_likes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestService_FetchBlogLikesByVisitId(t *testing.T) {
+	// モックリポジトリをインスタンス化
+	mockBlogLikeRepository := new(repositories_blogs_likes.MockBlogLikeRepository)
+	blogLikeService := NewBlogLikeService(mockBlogLikeRepository)
+
+	// モックデータの設定
+	mockData := []models.BlogLikeData{
+		{
+			BlogId:  "1",
+			VisitId: "1",
+		},
+		{
+			BlogId:  "2",
+			VisitId: "1",
+		},
+	}
+
+	// モックの設定
+	mockBlogLikeRepository.On("FetchBlogLikesByVisitId", "1").Return(mockData, nil)
+
+	// 実行
+	blogLikesData, err := blogLikeService.FetchBlogLikesByVisitId("1")
+
+	// エラーチェック
+	assert.NoError(t, err)
+	assert.Len(t, blogLikesData, 2)
+	assert.Equal(t, "1", blogLikesData[0].BlogId)
+
+	// モックが期待通りに呼び出されたかを確認
+	mockBlogLikeRepository.AssertExpectations(t)
+}
+
+func TestService_FetchBlogLikesByVisitId_InvalidVisitId(t *testing.T) {
+	// モックリポジトリをインスタンス化
+	mockBlogLikeRepository := new(repositories_blogs_likes.MockBlogLikeRepository)
+	blogLikeService := NewBlogLikeService(mockBlogLikeRepository)
+
+	// 実行
+	blogLikesData, err := blogLikeService.FetchBlogLikesByVisitId("")
+
+	// エラーチェック
+	assert.Error(t, err)
+	assert.Nil(t, blogLikesData)
+	assert.Contains(t, "visitId is empty", err.Error())
+
+	// モックの呼び出しを確認
+	mockBlogLikeRepository.AssertNotCalled(t, "FetchBlogLikesByVisitId", "")
+}
+
+func TestService_FetchBlogLikesByVisitId_NoData(t *testing.T) {
+	// モックリポジトリをインスタンス化
+	mockBlogLikeRepository := new(repositories_blogs_likes.MockBlogLikeRepository)
+	blogLikeService := NewBlogLikeService(mockBlogLikeRepository)
+
+	// モックの設定
+	mockBlogLikeRepository.On("FetchBlogLikesByVisitId", "1").Return(nil, errors.New("no data"))
+
+	// 実行
+	blogLikesData, err := blogLikeService.FetchBlogLikesByVisitId("1")
+
+	// エラーチェック
+	assert.Error(t, err)
+	assert.Nil(t, blogLikesData)
+	assert.Contains(t, "no data", err.Error())
+
+	// モックが期待通りに呼び出されたかを確認
+	mockBlogLikeRepository.AssertExpectations(t)
+}

--- a/services/blogs_likes/blogs_likes_impl.go
+++ b/services/blogs_likes/blogs_likes_impl.go
@@ -7,6 +7,7 @@ import (
 
 // BlogLikeServiceインターフェース
 type BlogLikeService interface {
+	FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikeData, error)
 	IsBlogLiked(blogId, visitId string) (bool, error)
 	CreateBlogLike(blogId, visitId string) (*models.BlogLikeData, error)
 	DeleteBlogLike(blogId, visitId string) error

--- a/services/blogs_likes/blogs_likes_mock.go
+++ b/services/blogs_likes/blogs_likes_mock.go
@@ -1,9 +1,21 @@
 package services_blogs_likes
 
-import "github.com/stretchr/testify/mock"
+import (
+	"backend/models"
+
+	"github.com/stretchr/testify/mock"
+)
 
 type MockBlogLikeService struct {
 	mock.Mock
+}
+
+func (m *MockBlogLikeService) FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikeData, error) {
+	args := m.Called(visitId)
+	if args.Get(0) != nil {
+		return args.Get(0).([]models.BlogLikeData), args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 func (m *MockBlogLikeService) IsBlogLiked(blogId, visitId string) (bool, error) {
@@ -11,9 +23,9 @@ func (m *MockBlogLikeService) IsBlogLiked(blogId, visitId string) (bool, error) 
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *MockBlogLikeService) CreateBlogLike(blogId, visitId string) error {
+func (m *MockBlogLikeService) CreateBlogLike(blogId, visitId string) (*models.BlogLikeData, error) {
 	args := m.Called(blogId, visitId)
-	return args.Error(0)
+	return args.Get(0).(*models.BlogLikeData), args.Error(1)
 }
 
 func (m *MockBlogLikeService) DeleteBlogLike(blogId, visitId string) error {


### PR DESCRIPTION
ブログ一覧側のいいね押下有無は、VisitIdからブログいいね取得する方法にしました。
ブログ全取得のSQLを変更すれば、もっとスムーズにいくと思いますが、
優先度低いため、後回しにしました。