### PR TITLE
chore(gha): deployワークフローにpathsフィルターを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ on:
         - 'go.sum'
         - 'Dockerfile'
         - '.github/workflows/**'
+      paths-ignore:
+        - '**/*_test.go'
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,12 @@ on:
     push:
       branches:
         - main
+      paths:
+        - '**/*.go'
+        - 'go.mod'
+        - 'go.sum'
+        - 'Dockerfile'
+        - '.github/workflows/**'
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## Summary
- `on.push.paths` を追加し、ドキュメント・Terraform等の変更でデプロイが発火しないよう制限
- 発火対象: `**/*.go`, `go.mod`, `go.sum`, `Dockerfile`, `.github/workflows/**`

## Test plan
- [ ] `docs/` 配下のファイルのみ変更してmainにマージしても GHA が発火しないこと
- [ ] Goソースを変更してmainにマージすると GHA が発火すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)