### PR TITLE
docs: 全公開識別子に godoc コメントを追加・形式統一

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -5,8 +5,10 @@ import (
 	"os"
 )
 
-// 環境変数から読み込む
+// JwtKey は環境変数 JWT_SECRET_KEY から読み込む JWT 署名鍵。
 var JwtKey = []byte(os.Getenv("JWT_SECRET_KEY"))
+
+// IsProduction は環境変数 ENV が "production" のとき true となる本番判定フラグ。
 var IsProduction = os.Getenv("ENV") == "production"
 
 func init() {

--- a/backend/handlers/auth/auth.go
+++ b/backend/handlers/auth/auth.go
@@ -12,6 +12,13 @@ type AuthHandler struct {
 }
 
 // NewAuthHandler は AuthHandler を生成する。
+//
+// 引数:
+//   - userService: ユーザーデータ取得に用いるユーザーサービス
+//   - authService: 認証処理に用いる認証サービス
+//
+// 戻り値:
+//   - *AuthHandler: 生成した認証ハンドラ
 func NewAuthHandler(userService services_users.UserService, authService services_auth.AuthService) *AuthHandler {
 	return &AuthHandler{
 		UserService: userService,

--- a/backend/handlers/auth/auth.go
+++ b/backend/handlers/auth/auth.go
@@ -5,12 +5,13 @@ import (
 	services_users "backend/services/blog_users"
 )
 
+// AuthHandler は認証系エンドポイントのハンドラ。
 type AuthHandler struct {
 	UserService services_users.UserService
 	AuthService services_auth.AuthService
 }
 
-// コンストラクタ
+// NewAuthHandler は AuthHandler を生成する。
 func NewAuthHandler(userService services_users.UserService, authService services_auth.AuthService) *AuthHandler {
 	return &AuthHandler{
 		UserService: userService,

--- a/backend/handlers/auth/auth_impl.go
+++ b/backend/handlers/auth/auth_impl.go
@@ -13,7 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// ログインエンドポイント（JWTトークンの発行）
+// Login はメール/パスワードで認証し JWT トークンを発行するログインエンドポイント。
 func (h *AuthHandler) Login(c echo.Context) error {
 	utils.LogInfo(c, "Logging in...")
 
@@ -90,7 +90,7 @@ func (h *AuthHandler) Login(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"message": "Login successful"})
 }
 
-// 認証確認エンドポイント
+// CheckAuth はクッキーの JWT トークンを検証する認証確認エンドポイント。
 func (h *AuthHandler) CheckAuth(c echo.Context) error {
 	utils.LogInfo(c, "Checking authentication...")
 
@@ -147,7 +147,7 @@ func (h *AuthHandler) CheckAuth(c echo.Context) error {
 	})
 }
 
-// ログアウトエンドポイント
+// Logout は認証クッキーを削除するログアウトエンドポイント。
 func (h *AuthHandler) Logout(c echo.Context) error {
 	utils.LogInfo(c, "Logging out...")
 

--- a/backend/handlers/auth/auth_impl.go
+++ b/backend/handlers/auth/auth_impl.go
@@ -14,6 +14,12 @@ import (
 )
 
 // Login はメール/パスワードで認証し JWT トークンを発行するログインエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（email/password を含む JSON ボディ）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。バインド/バリデーション失敗は 400、認証失敗は 401、トークン生成失敗等は 500 で返す
 func (h *AuthHandler) Login(c echo.Context) error {
 	utils.LogInfo(c, "Logging in...")
 
@@ -91,6 +97,12 @@ func (h *AuthHandler) Login(c echo.Context) error {
 }
 
 // CheckAuth はクッキーの JWT トークンを検証する認証確認エンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（token クッキーを含む）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。トークン不在/解析失敗/無効時は 401、成功時はユーザー情報を 200 で返す
 func (h *AuthHandler) CheckAuth(c echo.Context) error {
 	utils.LogInfo(c, "Checking authentication...")
 
@@ -148,6 +160,12 @@ func (h *AuthHandler) CheckAuth(c echo.Context) error {
 }
 
 // Logout は認証クッキーを削除するログアウトエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。成功時は 200 を返す
 func (h *AuthHandler) Logout(c echo.Context) error {
 	utils.LogInfo(c, "Logging out...")
 

--- a/backend/handlers/auth/auth_testing_setup.go
+++ b/backend/handlers/auth/auth_testing_setup.go
@@ -8,6 +8,9 @@ import (
 )
 
 // SetupTest はテストの前に環境変数を読み込み、ログ設定を初期化します
+//
+// 引数:
+//   - t: 環境変数ファイルが無い場合のログ出力に用いるテスト構造体
 func SetupTest(t *testing.T) {
 	err := godotenv.Load("../../.env.test")
 	if err != nil && t != nil {

--- a/backend/handlers/blog_comments/blog_comments.go
+++ b/backend/handlers/blog_comments/blog_comments.go
@@ -2,11 +2,12 @@ package handlers_blog_comments
 
 import services_comments "backend/services/blog_comments"
 
+// CommentHandler はブログコメント系エンドポイントのハンドラ。
 type CommentHandler struct {
 	CommentService services_comments.CommentService
 }
 
-// コンストラクタ
+// NewCommentHandler は CommentHandler を生成する。
 func NewCommentHandler(commentService services_comments.CommentService) *CommentHandler {
 	return &CommentHandler{
 		CommentService: commentService,

--- a/backend/handlers/blog_comments/blog_comments.go
+++ b/backend/handlers/blog_comments/blog_comments.go
@@ -8,6 +8,12 @@ type CommentHandler struct {
 }
 
 // NewCommentHandler は CommentHandler を生成する。
+//
+// 引数:
+//   - commentService: コメントデータの取得/作成に用いるコメントサービス
+//
+// 戻り値:
+//   - *CommentHandler: 生成したコメントハンドラ
 func NewCommentHandler(commentService services_comments.CommentService) *CommentHandler {
 	return &CommentHandler{
 		CommentService: commentService,

--- a/backend/handlers/blog_comments/blog_comments_impl.go
+++ b/backend/handlers/blog_comments/blog_comments_impl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// ブログIDでコメントデータを取得する
+// FetchCommentsByBlogId はブログ ID でコメントデータを取得するエンドポイント。
 func (h *CommentHandler) FetchCommentsByBlogId(c echo.Context) error {
 	utils.LogInfo(c, "Fetching comments by blogId...")
 
@@ -38,7 +38,7 @@ func (h *CommentHandler) FetchCommentsByBlogId(c echo.Context) error {
 	return c.JSON(http.StatusOK, comments)
 }
 
-// コメントデータを新規作成する
+// CreateComment はコメントデータを新規作成するエンドポイント。
 func (h *CommentHandler) CreateComment(c echo.Context) error {
 	utils.LogInfo(c, "Creating comment...")
 

--- a/backend/handlers/blog_comments/blog_comments_impl.go
+++ b/backend/handlers/blog_comments/blog_comments_impl.go
@@ -8,6 +8,12 @@ import (
 )
 
 // FetchCommentsByBlogId はブログ ID でコメントデータを取得するエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（パスパラメータ blogId を含む）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。不正な blogId は 400、コメント不在は 404、その他は 500 で返す
 func (h *CommentHandler) FetchCommentsByBlogId(c echo.Context) error {
 	utils.LogInfo(c, "Fetching comments by blogId...")
 
@@ -39,6 +45,12 @@ func (h *CommentHandler) FetchCommentsByBlogId(c echo.Context) error {
 }
 
 // CreateComment はコメントデータを新規作成するエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（blogId/guestUser/comment を含む JSON ボディ）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。バインド失敗や不正な入力は 400、作成失敗は 500、成功時は 201 で返す
 func (h *CommentHandler) CreateComment(c echo.Context) error {
 	utils.LogInfo(c, "Creating comment...")
 

--- a/backend/handlers/blog_likes/blog_likes.go
+++ b/backend/handlers/blog_likes/blog_likes.go
@@ -12,6 +12,13 @@ type BlogLikeHandler struct {
 }
 
 // NewBlogLikeHandler は BlogLikeHandler を生成する。
+//
+// 引数:
+//   - blogLikeService: いいねデータの取得/作成/削除に用いるいいねサービス
+//   - cookieUtils: 訪問者トークンの取得/生成に用いるクッキーユーティリティ
+//
+// 戻り値:
+//   - *BlogLikeHandler: 生成したいいねハンドラ
 func NewBlogLikeHandler(blogLikeService services_blogs_likes.BlogLikeService, cookieUtils utils_cookie.CookieUtils) *BlogLikeHandler {
 	return &BlogLikeHandler{
 		BlogLikeService: blogLikeService,

--- a/backend/handlers/blog_likes/blog_likes.go
+++ b/backend/handlers/blog_likes/blog_likes.go
@@ -5,12 +5,13 @@ import (
 	utils_cookie "backend/utils/cookie"
 )
 
+// BlogLikeHandler はブログいいね系エンドポイントのハンドラ。
 type BlogLikeHandler struct {
 	BlogLikeService services_blogs_likes.BlogLikeService
 	CookieUtils     utils_cookie.CookieUtils
 }
 
-// コンストラクタ
+// NewBlogLikeHandler は BlogLikeHandler を生成する。
 func NewBlogLikeHandler(blogLikeService services_blogs_likes.BlogLikeService, cookieUtils utils_cookie.CookieUtils) *BlogLikeHandler {
 	return &BlogLikeHandler{
 		BlogLikeService: blogLikeService,

--- a/backend/handlers/blog_likes/blog_likes_cookie_mock.go
+++ b/backend/handlers/blog_likes/blog_likes_cookie_mock.go
@@ -8,6 +8,11 @@ import (
 )
 
 // SetMockBlogCookies は、ブログ関連のクッキーを設定します
+//
+// 引数:
+//   - c: モックの期待値照合に用いる echo コンテキスト
+//   - req: クッキーを追加する対象の HTTP リクエスト
+//   - mockCookieUtils: 振る舞いを設定するクッキーユーティリティのモック
 func SetMockBlogCookies(c echo.Context, req *http.Request, mockCookieUtils *utils_cookie.MockCookieUtils) {
 	// JWT の署名キーを設定し、正しいトークンを生成
 	token := "mocked-token"

--- a/backend/handlers/blog_likes/blog_likes_impl.go
+++ b/backend/handlers/blog_likes/blog_likes_impl.go
@@ -8,6 +8,12 @@ import (
 )
 
 // FetchBlogLikesByVisitId - 訪問IDに紐づくブログいいねデータを取得するハンドラ
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（visit-id-token クッキーを含む）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。トークン取得/解析やデータ取得失敗時は 500、成功時は 200 で返す
 func (h *BlogLikeHandler) FetchBlogLikesByVisitId(c echo.Context) error {
 	utils.LogInfo(c, "Fetching blog likes by visit id...")
 
@@ -43,6 +49,12 @@ func (h *BlogLikeHandler) FetchBlogLikesByVisitId(c echo.Context) error {
 }
 
 // GenerateVisitorId -　訪問者IDを生成するハンドラ
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（既存の visit-id-token クッキーがあれば利用）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。トークン生成失敗時は 500、生成成功または既存時は 200 で返す
 func (h *BlogLikeHandler) GenerateVisitorId(c echo.Context) error {
 	utils.LogInfo(c, "Generating visitor id...")
 
@@ -80,6 +92,12 @@ func (h *BlogLikeHandler) GenerateVisitorId(c echo.Context) error {
 }
 
 // IsBlogLiked は対象ブログにいいね済みかを確認するハンドラ。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（visit-id-token クッキーとパスパラメータ blogId を含む）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。トークン取得/解析失敗時は 500、それ以外は isLiked を 200 で返す
 func (h *BlogLikeHandler) IsBlogLiked(c echo.Context) error {
 	utils.LogInfo(c, "Checking if blog is liked...")
 
@@ -119,6 +137,12 @@ func (h *BlogLikeHandler) IsBlogLiked(c echo.Context) error {
 }
 
 // CreateBlogLike はブログいいねを追加するハンドラ。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（visit-id-token クッキーとパスパラメータ blogId を含む）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。トークン取得/解析失敗は 500、空値やいいね済みは 400、成功時は 200 で返す
 func (h *BlogLikeHandler) CreateBlogLike(c echo.Context) error {
 	utils.LogInfo(c, "Creating blog like...")
 
@@ -167,6 +191,12 @@ func (h *BlogLikeHandler) CreateBlogLike(c echo.Context) error {
 }
 
 // DeleteBlogLike はブログいいねを削除するハンドラ。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（visit-id-token クッキーとパスパラメータ blogId を含む）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。トークン取得/解析や削除失敗時は 500、成功時は 200 で返す
 func (h *BlogLikeHandler) DeleteBlogLike(c echo.Context) error {
 	utils.LogInfo(c, "Deleting blog like...")
 

--- a/backend/handlers/blog_likes/blog_likes_impl.go
+++ b/backend/handlers/blog_likes/blog_likes_impl.go
@@ -79,7 +79,7 @@ func (h *BlogLikeHandler) GenerateVisitorId(c echo.Context) error {
 	})
 }
 
-// ブログいいねの取得ハンドラ
+// IsBlogLiked は対象ブログにいいね済みかを確認するハンドラ。
 func (h *BlogLikeHandler) IsBlogLiked(c echo.Context) error {
 	utils.LogInfo(c, "Checking if blog is liked...")
 
@@ -118,7 +118,7 @@ func (h *BlogLikeHandler) IsBlogLiked(c echo.Context) error {
 	})
 }
 
-// ブログいいねの追加ハンドラ
+// CreateBlogLike はブログいいねを追加するハンドラ。
 func (h *BlogLikeHandler) CreateBlogLike(c echo.Context) error {
 	utils.LogInfo(c, "Creating blog like...")
 
@@ -166,7 +166,7 @@ func (h *BlogLikeHandler) CreateBlogLike(c echo.Context) error {
 	return c.JSON(http.StatusOK, createdBlogLikeData)
 }
 
-// ブログいいねの削除ハンドラ
+// DeleteBlogLike はブログいいねを削除するハンドラ。
 func (h *BlogLikeHandler) DeleteBlogLike(c echo.Context) error {
 	utils.LogInfo(c, "Deleting blog like...")
 

--- a/backend/handlers/blog_users/blog_users.go
+++ b/backend/handlers/blog_users/blog_users.go
@@ -12,6 +12,13 @@ type BlogUsersHandler struct {
 }
 
 // NewBlogUsersHandler は BlogUsersHandler を生成する。
+//
+// 引数:
+//   - userService: ユーザーデータの取得/更新に用いるユーザーサービス
+//   - cookieUtils: 認証トークンの取得/再発行に用いるクッキーユーティリティ
+//
+// 戻り値:
+//   - *BlogUsersHandler: 生成したユーザーハンドラ
 func NewBlogUsersHandler(userService services_users.UserService, cookieUtils utils_cookie.CookieUtils) *BlogUsersHandler {
 	return &BlogUsersHandler{
 		UserService: userService,

--- a/backend/handlers/blog_users/blog_users.go
+++ b/backend/handlers/blog_users/blog_users.go
@@ -5,12 +5,13 @@ import (
 	utils_cookie "backend/utils/cookie"
 )
 
+// BlogUsersHandler はブログユーザー系エンドポイントのハンドラ。
 type BlogUsersHandler struct {
 	UserService services_users.UserService
 	CookieUtils utils_cookie.CookieUtils
 }
 
-// コンストラクタ
+// NewBlogUsersHandler は BlogUsersHandler を生成する。
 func NewBlogUsersHandler(userService services_users.UserService, cookieUtils utils_cookie.CookieUtils) *BlogUsersHandler {
 	return &BlogUsersHandler{
 		UserService: userService,

--- a/backend/handlers/blog_users/blog_users_cookie_mock.go
+++ b/backend/handlers/blog_users/blog_users_cookie_mock.go
@@ -8,6 +8,11 @@ import (
 )
 
 // SetMockBlogCookies は、ブログ関連のクッキーを設定します
+//
+// 引数:
+//   - c: モックの期待値照合に用いる echo コンテキスト
+//   - req: クッキーを追加する対象の HTTP リクエスト
+//   - mockCookieUtils: 振る舞いを設定するクッキーユーティリティのモック
 func SetMockBlogCookies(c echo.Context, req *http.Request, mockCookieUtils *utils_cookie.MockCookieUtils) {
 	// JWT の署名キーを設定し、正しいトークンを生成
 	token := "mocked-token"

--- a/backend/handlers/blog_users/blog_users_impl.go
+++ b/backend/handlers/blog_users/blog_users_impl.go
@@ -9,6 +9,12 @@ import (
 
 // GetUserByEmailAndPassword はリクエストボディの email と password でユーザーを取得するエンドポイント。
 // 有効な email フォーマットかをチェックし、データベースに該当ユーザーがいない場合、404 エラーを返す。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（email/password を含む JSON ボディ）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。バインド失敗や不正入力は 400、ユーザー不在は 404、その他は 500、成功時は 200 で返す
 func (h *BlogUsersHandler) GetUserByEmailAndPassword(c echo.Context) error {
 	utils.LogInfo(c, "Fetching user by email and password...")
 
@@ -56,6 +62,12 @@ func (h *BlogUsersHandler) GetUserByEmailAndPassword(c echo.Context) error {
 }
 
 // FetchBlogUsers はクッキーの JWT トークンから解決したユーザー ID でユーザーデータを取得するエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（token クッキーを含む）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。クッキー取得/解析失敗は 401、id 不正は 400、ユーザー不在は 404、その他は 500、成功時は 200 で返す
 func (h *BlogUsersHandler) FetchBlogUsers(c echo.Context) error {
 	utils.LogInfo(c, "Fetching user...")
 
@@ -105,6 +117,12 @@ func (h *BlogUsersHandler) FetchBlogUsers(c echo.Context) error {
 }
 
 // UpdateBlogUsers はユーザーデータを更新し、認証クッキーを再発行するエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（token クッキーと name/email/password/newPassword を含む JSON ボディ）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。クッキー取得/解析失敗は 401、不正入力は 400、ユーザー不在は 404、更新/トークン生成失敗は 500、成功時は 200 で返す
 func (h *BlogUsersHandler) UpdateBlogUsers(c echo.Context) error {
 	utils.LogInfo(c, "Updating user...")
 

--- a/backend/handlers/blog_users/blog_users_impl.go
+++ b/backend/handlers/blog_users/blog_users_impl.go
@@ -7,8 +7,8 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// リクエストボディで指定されたemailとpasswordでユーザーを取得する。
-// 有効なemailフォーマットかをチェックし、データベースに該当ユーザーがいない場合、404エラーを返す。
+// GetUserByEmailAndPassword はリクエストボディの email と password でユーザーを取得するエンドポイント。
+// 有効な email フォーマットかをチェックし、データベースに該当ユーザーがいない場合、404 エラーを返す。
 func (h *BlogUsersHandler) GetUserByEmailAndPassword(c echo.Context) error {
 	utils.LogInfo(c, "Fetching user by email and password...")
 
@@ -55,7 +55,7 @@ func (h *BlogUsersHandler) GetUserByEmailAndPassword(c echo.Context) error {
 	return c.JSON(http.StatusOK, user)
 }
 
-// ユーザーIDでユーザーデータを取得する
+// FetchBlogUsers はクッキーの JWT トークンから解決したユーザー ID でユーザーデータを取得するエンドポイント。
 func (h *BlogUsersHandler) FetchBlogUsers(c echo.Context) error {
 	utils.LogInfo(c, "Fetching user...")
 
@@ -104,7 +104,7 @@ func (h *BlogUsersHandler) FetchBlogUsers(c echo.Context) error {
 	return c.JSON(http.StatusOK, user)
 }
 
-// ユーザーデータを更新する
+// UpdateBlogUsers はユーザーデータを更新し、認証クッキーを再発行するエンドポイント。
 func (h *BlogUsersHandler) UpdateBlogUsers(c echo.Context) error {
 	utils.LogInfo(c, "Updating user...")
 

--- a/backend/handlers/blogs/blogs.go
+++ b/backend/handlers/blogs/blogs.go
@@ -5,12 +5,13 @@ import (
 	utils_cookie "backend/utils/cookie"
 )
 
+// BlogHandler はブログ系エンドポイントのハンドラ。
 type BlogHandler struct {
 	BlogService services_blogs.BlogService
 	CookieUtils utils_cookie.CookieUtils
 }
 
-// コンストラクタ
+// NewBlogHandler は BlogHandler を生成する。
 func NewBlogHandler(blogService services_blogs.BlogService, cookieUtils utils_cookie.CookieUtils) *BlogHandler {
 	return &BlogHandler{
 		BlogService: blogService,

--- a/backend/handlers/blogs/blogs.go
+++ b/backend/handlers/blogs/blogs.go
@@ -12,6 +12,13 @@ type BlogHandler struct {
 }
 
 // NewBlogHandler は BlogHandler を生成する。
+//
+// 引数:
+//   - blogService: ブログデータの取得/作成/更新/削除に用いるブログサービス
+//   - cookieUtils: 認証トークンの取得/解析に用いるクッキーユーティリティ
+//
+// 戻り値:
+//   - *BlogHandler: 生成したブログハンドラ
 func NewBlogHandler(blogService services_blogs.BlogService, cookieUtils utils_cookie.CookieUtils) *BlogHandler {
 	return &BlogHandler{
 		BlogService: blogService,

--- a/backend/handlers/blogs/blogs_cookie_mock.go
+++ b/backend/handlers/blogs/blogs_cookie_mock.go
@@ -8,6 +8,11 @@ import (
 )
 
 // SetMockBlogCookies は、ブログ関連のクッキーを設定します
+//
+// 引数:
+//   - c: モックの期待値照合に用いる echo コンテキスト
+//   - req: クッキーを追加する対象の HTTP リクエスト
+//   - mockCookieUtils: 振る舞いを設定するクッキーユーティリティのモック
 func SetMockBlogCookies(c echo.Context, req *http.Request, mockCookieUtils *utils_cookie.MockCookieUtils) {
 	// JWT の署名キーを設定し、正しいトークンを生成
 	token := "mocked-token"

--- a/backend/handlers/blogs/blogs_impl.go
+++ b/backend/handlers/blogs/blogs_impl.go
@@ -9,7 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// 全ブログデータを取得する
+// FetchBlogs は全ブログデータを取得するエンドポイント。
 func (h *BlogHandler) FetchBlogs(c echo.Context) error {
 	utils.LogInfo(c, "Fetching blogs...")
 
@@ -26,7 +26,7 @@ func (h *BlogHandler) FetchBlogs(c echo.Context) error {
 	return c.JSON(http.StatusOK, blogs)
 }
 
-// ユーザーIDでブログデータを取得する
+// FetchBlogsByUserId はユーザー ID でブログデータを取得するエンドポイント。
 func (h *BlogHandler) FetchBlogsByUserId(c echo.Context) error {
 	utils.LogInfo(c, "Fetching blogs by userId...")
 
@@ -57,7 +57,7 @@ func (h *BlogHandler) FetchBlogsByUserId(c echo.Context) error {
 	return c.JSON(http.StatusOK, blogs)
 }
 
-// ブログIDでブログデータを取得する
+// FetchBlogById はブログ ID でブログデータを取得するエンドポイント。
 func (h *BlogHandler) FetchBlogById(c echo.Context) error {
 	utils.LogInfo(c, "Fetching blog by id...")
 
@@ -88,7 +88,7 @@ func (h *BlogHandler) FetchBlogById(c echo.Context) error {
 	return c.JSON(http.StatusOK, blog)
 }
 
-// ブログデータを作成する
+// CreateBlog はブログデータを作成するエンドポイント。
 func (h *BlogHandler) CreateBlog(c echo.Context) error {
 	utils.LogInfo(c, "Creating blog...")
 
@@ -171,7 +171,7 @@ func (h *BlogHandler) CreateBlog(c echo.Context) error {
 	return c.JSON(http.StatusCreated, blog)
 }
 
-// ブログデータを更新する
+// UpdateBlog はブログデータを更新するエンドポイント。
 func (h *BlogHandler) UpdateBlog(c echo.Context) error {
 	utils.LogInfo(c, "Updating blog...")
 
@@ -257,7 +257,7 @@ func (h *BlogHandler) UpdateBlog(c echo.Context) error {
 	return c.JSON(http.StatusOK, blog)
 }
 
-// ブログデータを削除する
+// DeleteBlog はブログデータを削除するエンドポイント。
 func (h *BlogHandler) DeleteBlog(c echo.Context) error {
 	utils.LogInfo(c, "Deleting blog...")
 
@@ -306,7 +306,7 @@ func (h *BlogHandler) DeleteBlog(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
-// ブログカテゴリーの取得
+// FetchBlogCategories はブログカテゴリーを取得するエンドポイント。
 func (h *BlogHandler) FetchBlogCategories(c echo.Context) error {
 	utils.LogInfo(c, "Fetching categories...")
 
@@ -323,7 +323,7 @@ func (h *BlogHandler) FetchBlogCategories(c echo.Context) error {
 	return c.JSON(http.StatusOK, categories)
 }
 
-// ブログタグの取得
+// FetchBlogTags はブログタグを取得するエンドポイント。
 func (h *BlogHandler) FetchBlogTags(c echo.Context) error {
 	utils.LogInfo(c, "Fetching tags...")
 
@@ -340,7 +340,7 @@ func (h *BlogHandler) FetchBlogTags(c echo.Context) error {
 	return c.JSON(http.StatusOK, tags)
 }
 
-// 人気のあるブログの取得
+// FetchBlogPopular は人気のあるブログを指定件数取得するエンドポイント。
 func (h *BlogHandler) FetchBlogPopular(c echo.Context) error {
 	utils.LogInfo(c, "Fetching popular blogs...")
 

--- a/backend/handlers/blogs/blogs_impl.go
+++ b/backend/handlers/blogs/blogs_impl.go
@@ -10,6 +10,12 @@ import (
 )
 
 // FetchBlogs は全ブログデータを取得するエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。取得失敗時は 500、成功時は 200 で返す
 func (h *BlogHandler) FetchBlogs(c echo.Context) error {
 	utils.LogInfo(c, "Fetching blogs...")
 
@@ -27,6 +33,12 @@ func (h *BlogHandler) FetchBlogs(c echo.Context) error {
 }
 
 // FetchBlogsByUserId はユーザー ID でブログデータを取得するエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（パスパラメータ userId を含む）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。不正な userId は 400、ブログ不在は 404、その他は 500、成功時は 200 で返す
 func (h *BlogHandler) FetchBlogsByUserId(c echo.Context) error {
 	utils.LogInfo(c, "Fetching blogs by userId...")
 
@@ -58,6 +70,12 @@ func (h *BlogHandler) FetchBlogsByUserId(c echo.Context) error {
 }
 
 // FetchBlogById はブログ ID でブログデータを取得するエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（パスパラメータ id を含む）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。不正な id は 400、ブログ不在は 404、その他は 500、成功時は 200 で返す
 func (h *BlogHandler) FetchBlogById(c echo.Context) error {
 	utils.LogInfo(c, "Fetching blog by id...")
 
@@ -89,6 +107,12 @@ func (h *BlogHandler) FetchBlogById(c echo.Context) error {
 }
 
 // CreateBlog はブログデータを作成するエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（token クッキーと title/githubUrl/category/description/tags を含む JSON ボディ）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。クッキー取得/解析失敗は 401、不正入力は 400、作成失敗は 500、成功時は 201 で返す
 func (h *BlogHandler) CreateBlog(c echo.Context) error {
 	utils.LogInfo(c, "Creating blog...")
 
@@ -172,6 +196,12 @@ func (h *BlogHandler) CreateBlog(c echo.Context) error {
 }
 
 // UpdateBlog はブログデータを更新するエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（token クッキー、パスパラメータ id、更新内容を含む JSON ボディ）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。クッキー取得/解析失敗は 401、不正入力は 400、更新失敗は 500、成功時は 200 で返す
 func (h *BlogHandler) UpdateBlog(c echo.Context) error {
 	utils.LogInfo(c, "Updating blog...")
 
@@ -258,6 +288,12 @@ func (h *BlogHandler) UpdateBlog(c echo.Context) error {
 }
 
 // DeleteBlog はブログデータを削除するエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（token クッキーとパスパラメータ id を含む）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。クッキー取得/解析失敗は 401、不正な id は 400、削除失敗は 500、成功時は 204 で返す
 func (h *BlogHandler) DeleteBlog(c echo.Context) error {
 	utils.LogInfo(c, "Deleting blog...")
 
@@ -307,6 +343,12 @@ func (h *BlogHandler) DeleteBlog(c echo.Context) error {
 }
 
 // FetchBlogCategories はブログカテゴリーを取得するエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。取得失敗時は 500、成功時は 200 で返す
 func (h *BlogHandler) FetchBlogCategories(c echo.Context) error {
 	utils.LogInfo(c, "Fetching categories...")
 
@@ -324,6 +366,12 @@ func (h *BlogHandler) FetchBlogCategories(c echo.Context) error {
 }
 
 // FetchBlogTags はブログタグを取得するエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。取得失敗時は 500、成功時は 200 で返す
 func (h *BlogHandler) FetchBlogTags(c echo.Context) error {
 	utils.LogInfo(c, "Fetching tags...")
 
@@ -341,6 +389,12 @@ func (h *BlogHandler) FetchBlogTags(c echo.Context) error {
 }
 
 // FetchBlogPopular は人気のあるブログを指定件数取得するエンドポイント。
+//
+// 引数:
+//   - c: リクエスト/レスポンスを保持する echo コンテキスト（パスパラメータ count を含む）
+//
+// 戻り値:
+//   - error: レスポンス書き込みエラー。count が数値変換できない場合は 400、ブログ不在は 404、その他は 500、成功時は 200 で返す
 func (h *BlogHandler) FetchBlogPopular(c echo.Context) error {
 	utils.LogInfo(c, "Fetching popular blogs...")
 

--- a/backend/handlers/blogs/blogs_testing_setup.go
+++ b/backend/handlers/blogs/blogs_testing_setup.go
@@ -8,6 +8,9 @@ import (
 )
 
 // SetupTest はテストの前に環境変数を読み込み、ログ設定を初期化する。
+//
+// 引数:
+//   - t: 環境変数ファイルが無い場合のログ出力に用いるテスト構造体
 func SetupTest(t *testing.T) {
 	// 環境変数の読み込み
 	err := godotenv.Load("../../../.env.test")

--- a/backend/handlers/blogs/blogs_testing_setup.go
+++ b/backend/handlers/blogs/blogs_testing_setup.go
@@ -7,7 +7,7 @@ import (
 	"github.com/joho/godotenv"
 )
 
-// Setup はテストの前に環境変数を読み込み、ログ設定を初期化します
+// SetupTest はテストの前に環境変数を読み込み、ログ設定を初期化する。
 func SetupTest(t *testing.T) {
 	// 環境変数の読み込み
 	err := godotenv.Load("../../../.env.test")

--- a/backend/logger/logger.go
+++ b/backend/logger/logger.go
@@ -15,7 +15,7 @@ var (
 	TestLog  = log.New(os.Stdout, "TEST: ", log.Ldate|log.Ltime|log.Lshortfile)
 )
 
-// ログ設定の初期化
+// InitLogger はログ設定を初期化する。TEST_MODE 時は出力を破棄する。
 func InitLogger() {
 	if os.Getenv("TEST_MODE") == "true" {
 		InfoLog.SetOutput(io.Discard)

--- a/backend/middlewares/middlewares.go
+++ b/backend/middlewares/middlewares.go
@@ -8,7 +8,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
-// ミドルウェアの設定
+// SetupMiddlewares は Echo にロガー・リカバリー・CORS の各ミドルウェアを設定する。
 func SetupMiddlewares(e *echo.Echo) {
 	// ロガーとリカバリーミドルウェアを使用
 	e.Use(middleware.Logger())

--- a/backend/middlewares/middlewares.go
+++ b/backend/middlewares/middlewares.go
@@ -9,6 +9,9 @@ import (
 )
 
 // SetupMiddlewares は Echo にロガー・リカバリー・CORS の各ミドルウェアを設定する。
+//
+// 引数:
+//   - e: ミドルウェアを設定する対象の Echo インスタンス
 func SetupMiddlewares(e *echo.Echo) {
 	// ロガーとリカバリーミドルウェアを使用
 	e.Use(middleware.Logger())

--- a/backend/models/auth.go
+++ b/backend/models/auth.go
@@ -2,7 +2,7 @@ package models
 
 import "github.com/golang-jwt/jwt"
 
-// ユーザー情報のペイロード
+// Claims はユーザー情報を保持する JWT ペイロード。
 type Claims struct {
 	UserID   string `json:"user_id"`
 	Email    string `json:"email"`
@@ -10,7 +10,7 @@ type Claims struct {
 	jwt.StandardClaims
 }
 
-// 訪問者IDのペイロード
+// ClaimsVisitId は訪問者IDを保持する JWT ペイロード。
 type ClaimsVisitId struct {
 	VisitId string `json:"visit_id"`
 	jwt.StandardClaims

--- a/backend/models/blog_comments.go
+++ b/backend/models/blog_comments.go
@@ -2,7 +2,7 @@ package models
 
 import "time"
 
-// ブログのコメント情報を表すデータ構造
+// BlogCommentsData はブログのコメント情報を表すデータ構造。
 // 各フィールドには、JSONおよびデータベースのタグを指定。
 type BlogCommentsData struct {
 	ID        string    `json:"id" db:"id"`                 // UUID型

--- a/backend/models/blog_likes.go
+++ b/backend/models/blog_likes.go
@@ -2,7 +2,7 @@ package models
 
 import "time"
 
-// ブログのいいね情報を表すデータ構造
+// BlogLikesData はブログのいいね情報を表すデータ構造。
 // 各フィールドには、JSONおよびデータベースのタグを指定。
 type BlogLikesData struct {
 	ID        string    `json:"id" db:"id"`                 // UUID型

--- a/backend/models/blog_users.go
+++ b/backend/models/blog_users.go
@@ -2,7 +2,7 @@ package models
 
 import "time"
 
-// ブログユーザーの情報を表すデータ構造
+// BlogUsersData はブログユーザーの情報を表すデータ構造。
 // 各フィールドには、JSONおよびデータベースのタグを指定。
 type BlogUsersData struct {
 	ID        string    `json:"id" db:"id"`                 // UUID型

--- a/backend/models/blogs.go
+++ b/backend/models/blogs.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-// ブログの情報を表すデータ構造
+// BlogData はブログの情報を表すデータ構造。
 // 各フィールドには、JSONおよびデータベースのタグを指定。
 type BlogData struct {
 	ID          string    `json:"id" db:"id"`                     // UUID型

--- a/backend/repositories/auth/auth.go
+++ b/backend/repositories/auth/auth.go
@@ -1,10 +1,12 @@
 package repositories_auth
 
-// AuthRepositoryインターフェース
+// AuthRepository は認証系のデータアクセスを担うリポジトリインターフェース。
 type AuthRepository interface{}
+
+// AuthRepositoryImpl は AuthRepository の実装。
 type AuthRepositoryImpl struct{}
 
-// AuthRepositoryインターフェースを実装したAuthRepositoryImplのポインタを返す
+// NewAuthRepository は AuthRepository を実装した AuthRepositoryImpl のポインタを生成する。
 func NewAuthRepository() AuthRepository {
 	return &AuthRepositoryImpl{}
 }

--- a/backend/repositories/auth/auth.go
+++ b/backend/repositories/auth/auth.go
@@ -7,6 +7,9 @@ type AuthRepository interface{}
 type AuthRepositoryImpl struct{}
 
 // NewAuthRepository は AuthRepository を実装した AuthRepositoryImpl のポインタを生成する。
+//
+// 戻り値:
+//   - AuthRepository: 生成したリポジトリ実装
 func NewAuthRepository() AuthRepository {
 	return &AuthRepositoryImpl{}
 }

--- a/backend/repositories/blog_comments/blog_comments.go
+++ b/backend/repositories/blog_comments/blog_comments.go
@@ -2,15 +2,18 @@ package repositories_blog_comments
 
 import "backend/models"
 
-// CommentRepositoryインターフェース
+// CommentRepository はコメントのデータアクセスを担うリポジトリインターフェース。
 type CommentRepository interface {
+	// FetchCommentsByBlogId はブログIDに一致するコメント情報を取得する。
 	FetchCommentsByBlogId(blogId string) ([]models.BlogCommentsData, error)
+	// CreateComment はコメント情報を新規作成する。
 	CreateComment(blogId, guestUser, comment string) (*models.BlogCommentsData, error)
 }
 
+// CommentRepositoryImpl は CommentRepository の実装。
 type CommentRepositoryImpl struct{}
 
-// CommentRepositoryインターフェースを実装したCommentRepositoryImplのポインタを返す
+// NewCommentRepository は CommentRepository を実装した CommentRepositoryImpl のポインタを生成する。
 func NewCommentRepository() CommentRepository {
 	return &CommentRepositoryImpl{}
 }

--- a/backend/repositories/blog_comments/blog_comments.go
+++ b/backend/repositories/blog_comments/blog_comments.go
@@ -5,8 +5,24 @@ import "backend/models"
 // CommentRepository はコメントのデータアクセスを担うリポジトリインターフェース。
 type CommentRepository interface {
 	// FetchCommentsByBlogId はブログIDに一致するコメント情報を取得する。
+	//
+	// 引数:
+	//   - blogId: 取得対象のブログID
+	//
+	// 戻り値:
+	//   - []models.BlogCommentsData: 取得したコメント情報の一覧
+	//   - error: 取得に失敗した場合のエラー
 	FetchCommentsByBlogId(blogId string) ([]models.BlogCommentsData, error)
 	// CreateComment はコメント情報を新規作成する。
+	//
+	// 引数:
+	//   - blogId: コメント対象のブログID
+	//   - guestUser: コメントを投稿したゲストユーザー名
+	//   - comment: コメント本文
+	//
+	// 戻り値:
+	//   - *models.BlogCommentsData: 作成したコメント情報
+	//   - error: 作成に失敗した場合のエラー
 	CreateComment(blogId, guestUser, comment string) (*models.BlogCommentsData, error)
 }
 
@@ -14,6 +30,9 @@ type CommentRepository interface {
 type CommentRepositoryImpl struct{}
 
 // NewCommentRepository は CommentRepository を実装した CommentRepositoryImpl のポインタを生成する。
+//
+// 戻り値:
+//   - CommentRepository: 生成したリポジトリ実装
 func NewCommentRepository() CommentRepository {
 	return &CommentRepositoryImpl{}
 }

--- a/backend/repositories/blog_comments/blog_comments_impl.go
+++ b/backend/repositories/blog_comments/blog_comments_impl.go
@@ -7,6 +7,13 @@ import (
 )
 
 // FetchCommentsByBlogId はブログIDに一致するコメント情報を取得する。
+//
+// 引数:
+//   - blogId: 取得対象のブログID
+//
+// 戻り値:
+//   - []models.BlogCommentsData: 取得したコメント情報の一覧
+//   - error: 取得に失敗した場合のエラー
 func (r *CommentRepositoryImpl) FetchCommentsByBlogId(blogId string) ([]models.BlogCommentsData, error) {
 	log.Printf("FetchCommentsByBlogId start...")
 
@@ -54,6 +61,15 @@ func (r *CommentRepositoryImpl) FetchCommentsByBlogId(blogId string) ([]models.B
 }
 
 // CreateComment はコメント情報を新規作成する。
+//
+// 引数:
+//   - blogId: コメント対象のブログID
+//   - guestUser: コメントを投稿したゲストユーザー名
+//   - comment: コメント本文
+//
+// 戻り値:
+//   - *models.BlogCommentsData: 作成したコメント情報
+//   - error: 作成に失敗した場合のエラー
 func (r *CommentRepositoryImpl) CreateComment(blogId, guestUser, comment string) (*models.BlogCommentsData, error) {
 	log.Printf("CreateComment start...")
 

--- a/backend/repositories/blog_comments/blog_comments_impl.go
+++ b/backend/repositories/blog_comments/blog_comments_impl.go
@@ -6,7 +6,7 @@ import (
 	"log"
 )
 
-// ブログIDに一致するコメント情報を取得する
+// FetchCommentsByBlogId はブログIDに一致するコメント情報を取得する。
 func (r *CommentRepositoryImpl) FetchCommentsByBlogId(blogId string) ([]models.BlogCommentsData, error) {
 	log.Printf("FetchCommentsByBlogId start...")
 
@@ -53,7 +53,7 @@ func (r *CommentRepositoryImpl) FetchCommentsByBlogId(blogId string) ([]models.B
 	return comments, nil
 }
 
-// コメント情報を新規作成する
+// CreateComment はコメント情報を新規作成する。
 func (r *CommentRepositoryImpl) CreateComment(blogId, guestUser, comment string) (*models.BlogCommentsData, error) {
 	log.Printf("CreateComment start...")
 

--- a/backend/repositories/blog_comments/blog_comments_mock.go
+++ b/backend/repositories/blog_comments/blog_comments_mock.go
@@ -12,6 +12,13 @@ type MockCommentRepository struct {
 }
 
 // FetchCommentsByBlogId は CommentRepository.FetchCommentsByBlogId のモック実装。
+//
+// 引数:
+//   - blogId: 取得対象のブログID
+//
+// 戻り値:
+//   - []models.BlogCommentsData: モックの戻り値設定に従うコメント情報の一覧
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockCommentRepository) FetchCommentsByBlogId(blogId string) ([]models.BlogCommentsData, error) {
 	args := m.Called(blogId)
 	if args.Get(0) != nil {
@@ -21,6 +28,15 @@ func (m *MockCommentRepository) FetchCommentsByBlogId(blogId string) ([]models.B
 }
 
 // CreateComment は CommentRepository.CreateComment のモック実装。
+//
+// 引数:
+//   - blogId: コメント対象のブログID
+//   - guestUser: コメントを投稿したゲストユーザー名
+//   - comment: コメント本文
+//
+// 戻り値:
+//   - *models.BlogCommentsData: モックの戻り値設定に従う作成後のコメント情報
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockCommentRepository) CreateComment(blogId, guestUser, comment string) (*models.BlogCommentsData, error) {
 	args := m.Called(blogId, guestUser, comment)
 	if args.Get(0) != nil {

--- a/backend/repositories/blog_comments/blog_comments_mock.go
+++ b/backend/repositories/blog_comments/blog_comments_mock.go
@@ -6,10 +6,12 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// MockCommentRepository は CommentRepository のテスト用モック。
 type MockCommentRepository struct {
 	mock.Mock
 }
 
+// FetchCommentsByBlogId は CommentRepository.FetchCommentsByBlogId のモック実装。
 func (m *MockCommentRepository) FetchCommentsByBlogId(blogId string) ([]models.BlogCommentsData, error) {
 	args := m.Called(blogId)
 	if args.Get(0) != nil {
@@ -18,6 +20,7 @@ func (m *MockCommentRepository) FetchCommentsByBlogId(blogId string) ([]models.B
 	return nil, args.Error(1)
 }
 
+// CreateComment は CommentRepository.CreateComment のモック実装。
 func (m *MockCommentRepository) CreateComment(blogId, guestUser, comment string) (*models.BlogCommentsData, error) {
 	args := m.Called(blogId, guestUser, comment)
 	if args.Get(0) != nil {

--- a/backend/repositories/blog_likes/blog_likes.go
+++ b/backend/repositories/blog_likes/blog_likes.go
@@ -5,12 +5,42 @@ import "backend/models"
 // BlogLikeRepository はいいねのデータアクセスを担うリポジトリインターフェース。
 type BlogLikeRepository interface {
 	// FetchBlogLikesByVisitId は VisitId によっていいねデータを取得する。
+	//
+	// 引数:
+	//   - visitId: 取得対象の訪問者ID
+	//
+	// 戻り値:
+	//   - []models.BlogLikesData: 取得したいいねデータの一覧
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikesData, error)
 	// IsBlogLiked はいいねが存在するか確認する。
+	//
+	// 引数:
+	//   - blogId: 確認対象のブログID
+	//   - visitId: 確認対象の訪問者ID
+	//
+	// 戻り値:
+	//   - bool: いいねが存在する場合は true
+	//   - error: 確認に失敗した場合のエラー
 	IsBlogLiked(blogId, visitId string) (bool, error)
 	// CreateBlogLike はいいねデータを作成する。
+	//
+	// 引数:
+	//   - blogId: いいね対象のブログID
+	//   - visitId: いいねした訪問者ID
+	//
+	// 戻り値:
+	//   - *models.BlogLikesData: 作成したいいねデータ
+	//   - error: 作成に失敗した場合のエラー
 	CreateBlogLike(blogId, visitId string) (*models.BlogLikesData, error)
 	// DeleteBlogLike はいいねデータを削除する。
+	//
+	// 引数:
+	//   - blogId: 削除対象のブログID
+	//   - visitId: 削除対象の訪問者ID
+	//
+	// 戻り値:
+	//   - error: 削除に失敗した場合のエラー
 	DeleteBlogLike(blogId, visitId string) error
 }
 
@@ -18,6 +48,9 @@ type BlogLikeRepository interface {
 type BlogLikeRepositoryImpl struct{}
 
 // NewBlogLikeRepository は BlogLikeRepository を実装した BlogLikeRepositoryImpl のポインタを生成する。
+//
+// 戻り値:
+//   - BlogLikeRepository: 生成したリポジトリ実装
 func NewBlogLikeRepository() BlogLikeRepository {
 	return &BlogLikeRepositoryImpl{}
 }

--- a/backend/repositories/blog_likes/blog_likes.go
+++ b/backend/repositories/blog_likes/blog_likes.go
@@ -2,17 +2,22 @@ package repositories_blog_likes
 
 import "backend/models"
 
-// BlogLikeRepositoryインターフェース
+// BlogLikeRepository はいいねのデータアクセスを担うリポジトリインターフェース。
 type BlogLikeRepository interface {
+	// FetchBlogLikesByVisitId は VisitId によっていいねデータを取得する。
 	FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikesData, error)
+	// IsBlogLiked はいいねが存在するか確認する。
 	IsBlogLiked(blogId, visitId string) (bool, error)
+	// CreateBlogLike はいいねデータを作成する。
 	CreateBlogLike(blogId, visitId string) (*models.BlogLikesData, error)
+	// DeleteBlogLike はいいねデータを削除する。
 	DeleteBlogLike(blogId, visitId string) error
 }
 
+// BlogLikeRepositoryImpl は BlogLikeRepository の実装。
 type BlogLikeRepositoryImpl struct{}
 
-// BlogLikeRepositoryインターフェースを実装したBlogLikeRepositoryImplのポインタを返す
+// NewBlogLikeRepository は BlogLikeRepository を実装した BlogLikeRepositoryImpl のポインタを生成する。
 func NewBlogLikeRepository() BlogLikeRepository {
 	return &BlogLikeRepositoryImpl{}
 }

--- a/backend/repositories/blog_likes/blog_likes_impl.go
+++ b/backend/repositories/blog_likes/blog_likes_impl.go
@@ -7,6 +7,13 @@ import (
 )
 
 // FetchBlogLikesByVisitId は VisitId によっていいねデータを取得する。
+//
+// 引数:
+//   - visitId: 取得対象の訪問者ID
+//
+// 戻り値:
+//   - []models.BlogLikesData: 取得したいいねデータの一覧
+//   - error: 取得に失敗した場合のエラー
 func (r *BlogLikeRepositoryImpl) FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikesData, error) {
 	log.Println("FetchBlogLikesByVisitId start...")
 
@@ -43,6 +50,14 @@ func (r *BlogLikeRepositoryImpl) FetchBlogLikesByVisitId(visitId string) ([]mode
 }
 
 // IsBlogLiked はいいねが存在するか確認する。
+//
+// 引数:
+//   - blogId: 確認対象のブログID
+//   - visitId: 確認対象の訪問者ID
+//
+// 戻り値:
+//   - bool: いいねが存在する場合は true
+//   - error: 確認に失敗した場合のエラー
 func (r *BlogLikeRepositoryImpl) IsBlogLiked(blogId, visitId string) (bool, error) {
 	log.Println("IsBlogLiked start...")
 
@@ -68,6 +83,14 @@ func (r *BlogLikeRepositoryImpl) IsBlogLiked(blogId, visitId string) (bool, erro
 }
 
 // CreateBlogLike はいいねデータを作成する。
+//
+// 引数:
+//   - blogId: いいね対象のブログID
+//   - visitId: いいねした訪問者ID
+//
+// 戻り値:
+//   - *models.BlogLikesData: 作成したいいねデータ
+//   - error: 作成に失敗した場合のエラー
 func (r *BlogLikeRepositoryImpl) CreateBlogLike(blogId, visitId string) (*models.BlogLikesData, error) {
 	log.Println("CreateBlogLike start...")
 
@@ -93,6 +116,13 @@ func (r *BlogLikeRepositoryImpl) CreateBlogLike(blogId, visitId string) (*models
 }
 
 // DeleteBlogLike はいいねデータを削除する。
+//
+// 引数:
+//   - blogId: 削除対象のブログID
+//   - visitId: 削除対象の訪問者ID
+//
+// 戻り値:
+//   - error: 削除に失敗した場合のエラー
 func (r *BlogLikeRepositoryImpl) DeleteBlogLike(blogId, visitId string) error {
 	log.Println("DeleteBlogLike start...")
 

--- a/backend/repositories/blog_likes/blog_likes_impl.go
+++ b/backend/repositories/blog_likes/blog_likes_impl.go
@@ -6,7 +6,7 @@ import (
 	"log"
 )
 
-// VisitIdによっていいねデータを取得
+// FetchBlogLikesByVisitId は VisitId によっていいねデータを取得する。
 func (r *BlogLikeRepositoryImpl) FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikesData, error) {
 	log.Println("FetchBlogLikesByVisitId start...")
 
@@ -42,7 +42,7 @@ func (r *BlogLikeRepositoryImpl) FetchBlogLikesByVisitId(visitId string) ([]mode
 	return blogLikes, nil
 }
 
-// いいね存在するか確認
+// IsBlogLiked はいいねが存在するか確認する。
 func (r *BlogLikeRepositoryImpl) IsBlogLiked(blogId, visitId string) (bool, error) {
 	log.Println("IsBlogLiked start...")
 
@@ -67,7 +67,7 @@ func (r *BlogLikeRepositoryImpl) IsBlogLiked(blogId, visitId string) (bool, erro
 	return true, nil
 }
 
-// いいねデータの作成
+// CreateBlogLike はいいねデータを作成する。
 func (r *BlogLikeRepositoryImpl) CreateBlogLike(blogId, visitId string) (*models.BlogLikesData, error) {
 	log.Println("CreateBlogLike start...")
 
@@ -92,7 +92,7 @@ func (r *BlogLikeRepositoryImpl) CreateBlogLike(blogId, visitId string) (*models
 	return blogLike, nil
 }
 
-// いいねデータの削除
+// DeleteBlogLike はいいねデータを削除する。
 func (r *BlogLikeRepositoryImpl) DeleteBlogLike(blogId, visitId string) error {
 	log.Println("DeleteBlogLike start...")
 

--- a/backend/repositories/blog_likes/blog_likes_mock.go
+++ b/backend/repositories/blog_likes/blog_likes_mock.go
@@ -6,10 +6,12 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// MockBlogLikeRepository は BlogLikeRepository のテスト用モック。
 type MockBlogLikeRepository struct {
 	mock.Mock
 }
 
+// FetchBlogLikesByVisitId は BlogLikeRepository.FetchBlogLikesByVisitId のモック実装。
 func (m *MockBlogLikeRepository) FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikesData, error) {
 	args := m.Called(visitId)
 	if args.Get(0) != nil {
@@ -18,11 +20,13 @@ func (m *MockBlogLikeRepository) FetchBlogLikesByVisitId(visitId string) ([]mode
 	return nil, args.Error(1)
 }
 
+// IsBlogLiked は BlogLikeRepository.IsBlogLiked のモック実装。
 func (m *MockBlogLikeRepository) IsBlogLiked(blogId, visitId string) (bool, error) {
 	args := m.Called(blogId, visitId)
 	return args.Bool(0), args.Error(1)
 }
 
+// CreateBlogLike は BlogLikeRepository.CreateBlogLike のモック実装。
 func (m *MockBlogLikeRepository) CreateBlogLike(blogId, visitId string) (*models.BlogLikesData, error) {
 	args := m.Called(blogId, visitId)
 	if args.Get(0) == nil {
@@ -31,6 +35,7 @@ func (m *MockBlogLikeRepository) CreateBlogLike(blogId, visitId string) (*models
 	return args.Get(0).(*models.BlogLikesData), args.Error(1)
 }
 
+// DeleteBlogLike は BlogLikeRepository.DeleteBlogLike のモック実装。
 func (m *MockBlogLikeRepository) DeleteBlogLike(blogId, visitId string) error {
 	args := m.Called(blogId, visitId)
 	return args.Error(0)

--- a/backend/repositories/blog_likes/blog_likes_mock.go
+++ b/backend/repositories/blog_likes/blog_likes_mock.go
@@ -12,6 +12,13 @@ type MockBlogLikeRepository struct {
 }
 
 // FetchBlogLikesByVisitId は BlogLikeRepository.FetchBlogLikesByVisitId のモック実装。
+//
+// 引数:
+//   - visitId: 取得対象の訪問者ID
+//
+// 戻り値:
+//   - []models.BlogLikesData: モックの戻り値設定に従ういいねデータの一覧
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogLikeRepository) FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikesData, error) {
 	args := m.Called(visitId)
 	if args.Get(0) != nil {
@@ -21,12 +28,28 @@ func (m *MockBlogLikeRepository) FetchBlogLikesByVisitId(visitId string) ([]mode
 }
 
 // IsBlogLiked は BlogLikeRepository.IsBlogLiked のモック実装。
+//
+// 引数:
+//   - blogId: 確認対象のブログID
+//   - visitId: 確認対象の訪問者ID
+//
+// 戻り値:
+//   - bool: モックの戻り値設定に従ういいねの存在有無
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogLikeRepository) IsBlogLiked(blogId, visitId string) (bool, error) {
 	args := m.Called(blogId, visitId)
 	return args.Bool(0), args.Error(1)
 }
 
 // CreateBlogLike は BlogLikeRepository.CreateBlogLike のモック実装。
+//
+// 引数:
+//   - blogId: いいね対象のブログID
+//   - visitId: いいねした訪問者ID
+//
+// 戻り値:
+//   - *models.BlogLikesData: モックの戻り値設定に従う作成後のいいねデータ
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogLikeRepository) CreateBlogLike(blogId, visitId string) (*models.BlogLikesData, error) {
 	args := m.Called(blogId, visitId)
 	if args.Get(0) == nil {
@@ -36,6 +59,13 @@ func (m *MockBlogLikeRepository) CreateBlogLike(blogId, visitId string) (*models
 }
 
 // DeleteBlogLike は BlogLikeRepository.DeleteBlogLike のモック実装。
+//
+// 引数:
+//   - blogId: 削除対象のブログID
+//   - visitId: 削除対象の訪問者ID
+//
+// 戻り値:
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogLikeRepository) DeleteBlogLike(blogId, visitId string) error {
 	args := m.Called(blogId, visitId)
 	return args.Error(0)

--- a/backend/repositories/blog_users/blog_users.go
+++ b/backend/repositories/blog_users/blog_users.go
@@ -2,16 +2,20 @@ package repositories_blog_users
 
 import "backend/models"
 
-// BlogUsersRepositoryインターフェース
+// BlogUsersRepository はユーザーのデータアクセスを担うリポジトリインターフェース。
 type BlogUsersRepository interface {
+	// FetchBlogUsersByEmailAndPassword は指定されたメールアドレスとパスワードでユーザーを取得する。
 	FetchBlogUsersByEmailAndPassword(email, password string) (*models.BlogUsersData, error)
+	// FetchBlogUsersById は指定されたIDに一致するユーザーを取得する。
 	FetchBlogUsersById(id string) (*models.BlogUsersData, error)
+	// UpdateBlogUsers はユーザー情報を更新する。
 	UpdateBlogUsers(id, name, email, password string) (*models.BlogUsersData, error)
 }
 
+// BlogUsersRepositoryImpl は BlogUsersRepository の実装。
 type BlogUsersRepositoryImpl struct{}
 
-// BlogUsersRepositoryインターフェースを実装したBlogUsersRepositoryImplのポインタを返す
+// NewBlogUsersRepository は BlogUsersRepository を実装した BlogUsersRepositoryImpl のポインタを生成する。
 func NewBlogUsersRepository() BlogUsersRepository {
 	return &BlogUsersRepositoryImpl{}
 }

--- a/backend/repositories/blog_users/blog_users.go
+++ b/backend/repositories/blog_users/blog_users.go
@@ -5,10 +5,35 @@ import "backend/models"
 // BlogUsersRepository はユーザーのデータアクセスを担うリポジトリインターフェース。
 type BlogUsersRepository interface {
 	// FetchBlogUsersByEmailAndPassword は指定されたメールアドレスとパスワードでユーザーを取得する。
+	//
+	// 引数:
+	//   - email: 取得対象のメールアドレス
+	//   - password: 認証に用いるパスワード
+	//
+	// 戻り値:
+	//   - *models.BlogUsersData: 取得したユーザー情報
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogUsersByEmailAndPassword(email, password string) (*models.BlogUsersData, error)
 	// FetchBlogUsersById は指定されたIDに一致するユーザーを取得する。
+	//
+	// 引数:
+	//   - id: 取得対象のユーザーID
+	//
+	// 戻り値:
+	//   - *models.BlogUsersData: 取得したユーザー情報
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogUsersById(id string) (*models.BlogUsersData, error)
 	// UpdateBlogUsers はユーザー情報を更新する。
+	//
+	// 引数:
+	//   - id: 更新対象のユーザーID
+	//   - name: 更新後のユーザー名
+	//   - email: 更新後のメールアドレス
+	//   - password: 更新後のパスワード
+	//
+	// 戻り値:
+	//   - *models.BlogUsersData: 更新後のユーザー情報
+	//   - error: 更新に失敗した場合のエラー
 	UpdateBlogUsers(id, name, email, password string) (*models.BlogUsersData, error)
 }
 
@@ -16,6 +41,9 @@ type BlogUsersRepository interface {
 type BlogUsersRepositoryImpl struct{}
 
 // NewBlogUsersRepository は BlogUsersRepository を実装した BlogUsersRepositoryImpl のポインタを生成する。
+//
+// 戻り値:
+//   - BlogUsersRepository: 生成したリポジトリ実装
 func NewBlogUsersRepository() BlogUsersRepository {
 	return &BlogUsersRepositoryImpl{}
 }

--- a/backend/repositories/blog_users/blog_users_impl.go
+++ b/backend/repositories/blog_users/blog_users_impl.go
@@ -8,6 +8,14 @@ import (
 
 // FetchBlogUsersByEmailAndPassword は指定されたメールアドレスとパスワードでユーザーを取得する。
 // ユーザーが見つからない場合、エラーを返す。
+//
+// 引数:
+//   - email: 取得対象のメールアドレス
+//   - password: 認証に用いるパスワード
+//
+// 戻り値:
+//   - *models.BlogUsersData: 取得したユーザー情報
+//   - error: 取得に失敗した場合のエラー
 func (r *BlogUsersRepositoryImpl) FetchBlogUsersByEmailAndPassword(email, password string) (*models.BlogUsersData, error) {
 	log.Printf("Fetching user from Supabase by email: %s\n", email)
 
@@ -40,6 +48,13 @@ func (r *BlogUsersRepositoryImpl) FetchBlogUsersByEmailAndPassword(email, passwo
 }
 
 // FetchBlogUsersById は指定されたIDに一致するユーザーを取得する。
+//
+// 引数:
+//   - id: 取得対象のユーザーID
+//
+// 戻り値:
+//   - *models.BlogUsersData: 取得したユーザー情報
+//   - error: 取得に失敗した場合のエラー
 func (r *BlogUsersRepositoryImpl) FetchBlogUsersById(id string) (*models.BlogUsersData, error) {
 	log.Println("Fetching user from Supabase by ID")
 
@@ -73,6 +88,16 @@ func (r *BlogUsersRepositoryImpl) FetchBlogUsersById(id string) (*models.BlogUse
 }
 
 // UpdateBlogUsers はユーザー情報を更新する。
+//
+// 引数:
+//   - id: 更新対象のユーザーID
+//   - name: 更新後のユーザー名
+//   - email: 更新後のメールアドレス
+//   - password: 更新後のパスワード
+//
+// 戻り値:
+//   - *models.BlogUsersData: 更新後のユーザー情報
+//   - error: 更新に失敗した場合のエラー
 func (r *BlogUsersRepositoryImpl) UpdateBlogUsers(id, name, email, password string) (*models.BlogUsersData, error) {
 	log.Println("Updating user in Supabase")
 

--- a/backend/repositories/blog_users/blog_users_impl.go
+++ b/backend/repositories/blog_users/blog_users_impl.go
@@ -6,7 +6,7 @@ import (
 	"log"
 )
 
-// 指定されたメールアドレスとパスワードでユーザーを取得する。
+// FetchBlogUsersByEmailAndPassword は指定されたメールアドレスとパスワードでユーザーを取得する。
 // ユーザーが見つからない場合、エラーを返す。
 func (r *BlogUsersRepositoryImpl) FetchBlogUsersByEmailAndPassword(email, password string) (*models.BlogUsersData, error) {
 	log.Printf("Fetching user from Supabase by email: %s\n", email)
@@ -39,7 +39,7 @@ func (r *BlogUsersRepositoryImpl) FetchBlogUsersByEmailAndPassword(email, passwo
 	return &user, nil
 }
 
-// 指定されたIDに一致するユーザーを取得する
+// FetchBlogUsersById は指定されたIDに一致するユーザーを取得する。
 func (r *BlogUsersRepositoryImpl) FetchBlogUsersById(id string) (*models.BlogUsersData, error) {
 	log.Println("Fetching user from Supabase by ID")
 
@@ -72,7 +72,7 @@ func (r *BlogUsersRepositoryImpl) FetchBlogUsersById(id string) (*models.BlogUse
 	return &user, nil
 }
 
-// ユーザー情報を更新する
+// UpdateBlogUsers はユーザー情報を更新する。
 func (r *BlogUsersRepositoryImpl) UpdateBlogUsers(id, name, email, password string) (*models.BlogUsersData, error) {
 	log.Println("Updating user in Supabase")
 

--- a/backend/repositories/blog_users/blog_users_mock.go
+++ b/backend/repositories/blog_users/blog_users_mock.go
@@ -12,6 +12,14 @@ type MockUserRepository struct {
 }
 
 // FetchBlogUsersByEmailAndPassword は BlogUsersRepository.FetchBlogUsersByEmailAndPassword のモック実装。
+//
+// 引数:
+//   - email: 取得対象のメールアドレス
+//   - password: 認証に用いるパスワード
+//
+// 戻り値:
+//   - *models.BlogUsersData: モックの戻り値設定に従うユーザー情報
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockUserRepository) FetchBlogUsersByEmailAndPassword(email, password string) (*models.BlogUsersData, error) {
 	args := m.Called(email, password)
 	if args.Get(0) != nil {
@@ -21,6 +29,13 @@ func (m *MockUserRepository) FetchBlogUsersByEmailAndPassword(email, password st
 }
 
 // FetchBlogUsersById は BlogUsersRepository.FetchBlogUsersById のモック実装。
+//
+// 引数:
+//   - id: 取得対象のユーザーID
+//
+// 戻り値:
+//   - *models.BlogUsersData: モックの戻り値設定に従うユーザー情報
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockUserRepository) FetchBlogUsersById(id string) (*models.BlogUsersData, error) {
 	args := m.Called(id)
 	if args.Get(0) != nil {
@@ -30,6 +45,16 @@ func (m *MockUserRepository) FetchBlogUsersById(id string) (*models.BlogUsersDat
 }
 
 // UpdateBlogUsers は BlogUsersRepository.UpdateBlogUsers のモック実装。
+//
+// 引数:
+//   - id: 更新対象のユーザーID
+//   - name: 更新後のユーザー名
+//   - email: 更新後のメールアドレス
+//   - password: 更新後のパスワード
+//
+// 戻り値:
+//   - *models.BlogUsersData: モックの戻り値設定に従う更新後のユーザー情報
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockUserRepository) UpdateBlogUsers(id, name, email, password string) (*models.BlogUsersData, error) {
 	args := m.Called(id, name, email, password)
 	if args.Get(0) != nil {

--- a/backend/repositories/blog_users/blog_users_mock.go
+++ b/backend/repositories/blog_users/blog_users_mock.go
@@ -6,10 +6,12 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// MockUserRepository は BlogUsersRepository のテスト用モック。
 type MockUserRepository struct {
 	mock.Mock
 }
 
+// FetchBlogUsersByEmailAndPassword は BlogUsersRepository.FetchBlogUsersByEmailAndPassword のモック実装。
 func (m *MockUserRepository) FetchBlogUsersByEmailAndPassword(email, password string) (*models.BlogUsersData, error) {
 	args := m.Called(email, password)
 	if args.Get(0) != nil {
@@ -18,6 +20,7 @@ func (m *MockUserRepository) FetchBlogUsersByEmailAndPassword(email, password st
 	return nil, args.Error(1)
 }
 
+// FetchBlogUsersById は BlogUsersRepository.FetchBlogUsersById のモック実装。
 func (m *MockUserRepository) FetchBlogUsersById(id string) (*models.BlogUsersData, error) {
 	args := m.Called(id)
 	if args.Get(0) != nil {
@@ -26,6 +29,7 @@ func (m *MockUserRepository) FetchBlogUsersById(id string) (*models.BlogUsersDat
 	return nil, args.Error(1)
 }
 
+// UpdateBlogUsers は BlogUsersRepository.UpdateBlogUsers のモック実装。
 func (m *MockUserRepository) UpdateBlogUsers(id, name, email, password string) (*models.BlogUsersData, error) {
 	args := m.Called(id, name, email, password)
 	if args.Get(0) != nil {

--- a/backend/repositories/blogs/blogs.go
+++ b/backend/repositories/blogs/blogs.go
@@ -5,24 +5,87 @@ import "backend/models"
 // BlogRepository はブログのデータアクセスを担うリポジトリインターフェース。
 type BlogRepository interface {
 	// FetchBlogs は全ブログデータを取得する。
+	//
+	// 戻り値:
+	//   - []models.BlogData: 取得した全ブログデータの一覧
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogs() ([]models.BlogData, error)
 	// FetchBlogsByUserId は指定されたユーザーIDに一致するブログデータを取得する。
+	//
+	// 引数:
+	//   - userId: 取得対象のユーザーID
+	//
+	// 戻り値:
+	//   - []models.BlogData: 取得したブログデータの一覧
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogsByUserId(userId string) ([]models.BlogData, error)
 	// FetchBlogById は指定されたIDに一致するブログデータを取得する。
+	//
+	// 引数:
+	//   - id: 取得対象のブログID
+	//
+	// 戻り値:
+	//   - *models.BlogData: 取得したブログデータ
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogById(id string) (*models.BlogData, error)
 
 	// CreateBlog はブログデータを作成する。
+	//
+	// 引数:
+	//   - userId: 作成者のユーザーID
+	//   - title: ブログのタイトル
+	//   - githubUrl: 関連する GitHub の URL
+	//   - category: ブログのカテゴリ
+	//   - description: ブログの説明
+	//   - tags: ブログのタグ
+	//
+	// 戻り値:
+	//   - *models.BlogData: 作成したブログデータ
+	//   - error: 作成に失敗した場合のエラー
 	CreateBlog(userId, title, githubUrl, category, description, tags string) (*models.BlogData, error)
 	// UpdateBlog はブログデータを更新する。
+	//
+	// 引数:
+	//   - id: 更新対象のブログID
+	//   - title: 更新後のタイトル
+	//   - githubUrl: 更新後の GitHub の URL
+	//   - category: 更新後のカテゴリ
+	//   - description: 更新後の説明
+	//   - tags: 更新後のタグ
+	//
+	// 戻り値:
+	//   - *models.BlogData: 更新後のブログデータ
+	//   - error: 更新に失敗した場合のエラー
 	UpdateBlog(id, title, githubUrl, category, description, tags string) (*models.BlogData, error)
 	// DeleteBlog はブログデータを削除する。
+	//
+	// 引数:
+	//   - id: 削除対象のブログID
+	//
+	// 戻り値:
+	//   - error: 削除に失敗した場合のエラー
 	DeleteBlog(id string) error
 
 	// FetchBlogCategories はブログカテゴリ一覧を取得する。
+	//
+	// 戻り値:
+	//   - []string: 取得したカテゴリ一覧
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogCategories() ([]string, error)
 	// FetchBlogTags はブログタグ一覧を取得する。
+	//
+	// 戻り値:
+	//   - []string: 取得したタグ一覧
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogTags() ([]string, error)
 	// FetchBlogPopular は人気のあるブログを取得する。
+	//
+	// 引数:
+	//   - count: 取得する件数
+	//
+	// 戻り値:
+	//   - []models.BlogData: 取得した人気ブログデータの一覧
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogPopular(count int) ([]models.BlogData, error)
 }
 
@@ -30,6 +93,9 @@ type BlogRepository interface {
 type BlogRepositoryImpl struct{}
 
 // NewBlogRepository は BlogRepository を実装した BlogRepositoryImpl のポインタを生成する。
+//
+// 戻り値:
+//   - BlogRepository: 生成したリポジトリ実装
 func NewBlogRepository() BlogRepository {
 	return &BlogRepositoryImpl{}
 }

--- a/backend/repositories/blogs/blogs.go
+++ b/backend/repositories/blogs/blogs.go
@@ -2,24 +2,34 @@ package repositories_blogs
 
 import "backend/models"
 
-// BlogRepositoryインターフェース
+// BlogRepository はブログのデータアクセスを担うリポジトリインターフェース。
 type BlogRepository interface {
+	// FetchBlogs は全ブログデータを取得する。
 	FetchBlogs() ([]models.BlogData, error)
+	// FetchBlogsByUserId は指定されたユーザーIDに一致するブログデータを取得する。
 	FetchBlogsByUserId(userId string) ([]models.BlogData, error)
+	// FetchBlogById は指定されたIDに一致するブログデータを取得する。
 	FetchBlogById(id string) (*models.BlogData, error)
 
+	// CreateBlog はブログデータを作成する。
 	CreateBlog(userId, title, githubUrl, category, description, tags string) (*models.BlogData, error)
+	// UpdateBlog はブログデータを更新する。
 	UpdateBlog(id, title, githubUrl, category, description, tags string) (*models.BlogData, error)
+	// DeleteBlog はブログデータを削除する。
 	DeleteBlog(id string) error
 
+	// FetchBlogCategories はブログカテゴリ一覧を取得する。
 	FetchBlogCategories() ([]string, error)
+	// FetchBlogTags はブログタグ一覧を取得する。
 	FetchBlogTags() ([]string, error)
+	// FetchBlogPopular は人気のあるブログを取得する。
 	FetchBlogPopular(count int) ([]models.BlogData, error)
 }
 
+// BlogRepositoryImpl は BlogRepository の実装。
 type BlogRepositoryImpl struct{}
 
-// BlogRepositoryインターフェースを実装したBlogRepositoryImplのポインタを返す
+// NewBlogRepository は BlogRepository を実装した BlogRepositoryImpl のポインタを生成する。
 func NewBlogRepository() BlogRepository {
 	return &BlogRepositoryImpl{}
 }

--- a/backend/repositories/blogs/blogs_impl.go
+++ b/backend/repositories/blogs/blogs_impl.go
@@ -10,6 +10,10 @@ import (
 )
 
 // FetchBlogs は全ブログデータを取得する。
+//
+// 戻り値:
+//   - []models.BlogData: 取得した全ブログデータの一覧
+//   - error: 取得に失敗した場合のエラー
 func (r *BlogRepositoryImpl) FetchBlogs() ([]models.BlogData, error) {
 	logger.InfoLog.Printf("FetchBlogs start...")
 
@@ -84,6 +88,13 @@ func (r *BlogRepositoryImpl) FetchBlogs() ([]models.BlogData, error) {
 }
 
 // FetchBlogsByUserId は指定されたユーザーIDに一致するブログデータを取得する。
+//
+// 引数:
+//   - userId: 取得対象のユーザーID
+//
+// 戻り値:
+//   - []models.BlogData: 取得したブログデータの一覧
+//   - error: 取得に失敗した場合のエラー
 func (r *BlogRepositoryImpl) FetchBlogsByUserId(userId string) ([]models.BlogData, error) {
 	logger.InfoLog.Printf("FetchBlogsByUserId start...")
 
@@ -160,6 +171,13 @@ func (r *BlogRepositoryImpl) FetchBlogsByUserId(userId string) ([]models.BlogDat
 }
 
 // FetchBlogById は指定されたIDに一致するブログデータを取得する。
+//
+// 引数:
+//   - id: 取得対象のブログID
+//
+// 戻り値:
+//   - *models.BlogData: 取得したブログデータ
+//   - error: 取得に失敗した場合のエラー
 func (r *BlogRepositoryImpl) FetchBlogById(id string) (*models.BlogData, error) {
 	logger.InfoLog.Printf("FetchBlogById start...")
 
@@ -217,6 +235,18 @@ func (r *BlogRepositoryImpl) FetchBlogById(id string) (*models.BlogData, error) 
 }
 
 // CreateBlog はブログデータを作成する。
+//
+// 引数:
+//   - userId: 作成者のユーザーID
+//   - title: ブログのタイトル
+//   - githubUrl: 関連する GitHub の URL
+//   - category: ブログのカテゴリ
+//   - description: ブログの説明
+//   - tags: ブログのタグ
+//
+// 戻り値:
+//   - *models.BlogData: 作成したブログデータ
+//   - error: 作成に失敗した場合のエラー
 func (r *BlogRepositoryImpl) CreateBlog(userId, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	logger.InfoLog.Printf("CreateBlog start...")
 
@@ -260,6 +290,18 @@ func (r *BlogRepositoryImpl) CreateBlog(userId, title, githubUrl, category, desc
 }
 
 // UpdateBlog はブログデータを更新する。
+//
+// 引数:
+//   - id: 更新対象のブログID
+//   - title: 更新後のタイトル
+//   - githubUrl: 更新後の GitHub の URL
+//   - category: 更新後のカテゴリ
+//   - description: 更新後の説明
+//   - tags: 更新後のタグ
+//
+// 戻り値:
+//   - *models.BlogData: 更新後のブログデータ
+//   - error: 更新に失敗した場合のエラー
 func (r *BlogRepositoryImpl) UpdateBlog(id, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	logger.InfoLog.Printf("UpdateBlog start...")
 
@@ -323,6 +365,12 @@ func (r *BlogRepositoryImpl) UpdateBlog(id, title, githubUrl, category, descript
 }
 
 // DeleteBlog はブログデータを削除する。
+//
+// 引数:
+//   - id: 削除対象のブログID
+//
+// 戻り値:
+//   - error: 削除に失敗した場合のエラー
 func (r *BlogRepositoryImpl) DeleteBlog(id string) error {
 	logger.InfoLog.Printf("DeleteBlog start...")
 
@@ -350,6 +398,10 @@ func (r *BlogRepositoryImpl) DeleteBlog(id string) error {
 }
 
 // FetchBlogCategories はブログカテゴリ一覧を取得する。
+//
+// 戻り値:
+//   - []string: 取得したカテゴリ一覧
+//   - error: 取得に失敗した場合のエラー
 func (r *BlogRepositoryImpl) FetchBlogCategories() ([]string, error) {
 	logger.InfoLog.Printf("FetchBlogCategories start...")
 
@@ -393,6 +445,10 @@ func (r *BlogRepositoryImpl) FetchBlogCategories() ([]string, error) {
 }
 
 // FetchBlogTags はブログタグ一覧を取得する。
+//
+// 戻り値:
+//   - []string: 取得したタグ一覧
+//   - error: 取得に失敗した場合のエラー
 func (r *BlogRepositoryImpl) FetchBlogTags() ([]string, error) {
 	logger.InfoLog.Printf("FetchBlogTags start...")
 
@@ -436,6 +492,13 @@ func (r *BlogRepositoryImpl) FetchBlogTags() ([]string, error) {
 }
 
 // FetchBlogPopular は人気のあるブログを取得する。
+//
+// 引数:
+//   - count: 取得する件数
+//
+// 戻り値:
+//   - []models.BlogData: 取得した人気ブログデータの一覧
+//   - error: 取得に失敗した場合のエラー
 func (r *BlogRepositoryImpl) FetchBlogPopular(count int) ([]models.BlogData, error) {
 	logger.InfoLog.Printf("FetchBlogPopular start...")
 

--- a/backend/repositories/blogs/blogs_impl.go
+++ b/backend/repositories/blogs/blogs_impl.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// 全ブログデータを取得する
+// FetchBlogs は全ブログデータを取得する。
 func (r *BlogRepositoryImpl) FetchBlogs() ([]models.BlogData, error) {
 	logger.InfoLog.Printf("FetchBlogs start...")
 
@@ -83,7 +83,7 @@ func (r *BlogRepositoryImpl) FetchBlogs() ([]models.BlogData, error) {
 	return blogs, nil
 }
 
-// 指定されたユーザーIDに一致するブログデータを取得する
+// FetchBlogsByUserId は指定されたユーザーIDに一致するブログデータを取得する。
 func (r *BlogRepositoryImpl) FetchBlogsByUserId(userId string) ([]models.BlogData, error) {
 	logger.InfoLog.Printf("FetchBlogsByUserId start...")
 
@@ -159,7 +159,7 @@ func (r *BlogRepositoryImpl) FetchBlogsByUserId(userId string) ([]models.BlogDat
 	return blogs, nil
 }
 
-// 指定されたIDに一致するブログデータを取得する
+// FetchBlogById は指定されたIDに一致するブログデータを取得する。
 func (r *BlogRepositoryImpl) FetchBlogById(id string) (*models.BlogData, error) {
 	logger.InfoLog.Printf("FetchBlogById start...")
 
@@ -216,7 +216,7 @@ func (r *BlogRepositoryImpl) FetchBlogById(id string) (*models.BlogData, error) 
 	return &blog, nil
 }
 
-// ブログデータの作成
+// CreateBlog はブログデータを作成する。
 func (r *BlogRepositoryImpl) CreateBlog(userId, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	logger.InfoLog.Printf("CreateBlog start...")
 
@@ -259,7 +259,7 @@ func (r *BlogRepositoryImpl) CreateBlog(userId, title, githubUrl, category, desc
 	return &blog, nil
 }
 
-// ブログデータの更新
+// UpdateBlog はブログデータを更新する。
 func (r *BlogRepositoryImpl) UpdateBlog(id, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	logger.InfoLog.Printf("UpdateBlog start...")
 
@@ -322,7 +322,7 @@ func (r *BlogRepositoryImpl) UpdateBlog(id, title, githubUrl, category, descript
 	return &blog, nil
 }
 
-// ブログデータの削除
+// DeleteBlog はブログデータを削除する。
 func (r *BlogRepositoryImpl) DeleteBlog(id string) error {
 	logger.InfoLog.Printf("DeleteBlog start...")
 
@@ -349,7 +349,7 @@ func (r *BlogRepositoryImpl) DeleteBlog(id string) error {
 	return nil
 }
 
-// ブログカテゴリ一覧を取得する
+// FetchBlogCategories はブログカテゴリ一覧を取得する。
 func (r *BlogRepositoryImpl) FetchBlogCategories() ([]string, error) {
 	logger.InfoLog.Printf("FetchBlogCategories start...")
 
@@ -392,7 +392,7 @@ func (r *BlogRepositoryImpl) FetchBlogCategories() ([]string, error) {
 	return categories, nil
 }
 
-// ブログタグ一覧を取得する
+// FetchBlogTags はブログタグ一覧を取得する。
 func (r *BlogRepositoryImpl) FetchBlogTags() ([]string, error) {
 	logger.InfoLog.Printf("FetchBlogTags start...")
 
@@ -435,7 +435,7 @@ func (r *BlogRepositoryImpl) FetchBlogTags() ([]string, error) {
 	return tags, nil
 }
 
-// 人気のあるブログを取得する
+// FetchBlogPopular は人気のあるブログを取得する。
 func (r *BlogRepositoryImpl) FetchBlogPopular(count int) ([]models.BlogData, error) {
 	logger.InfoLog.Printf("FetchBlogPopular start...")
 

--- a/backend/repositories/blogs/blogs_mock.go
+++ b/backend/repositories/blogs/blogs_mock.go
@@ -12,6 +12,10 @@ type MockBlogRepository struct {
 }
 
 // FetchBlogs は BlogRepository.FetchBlogs のモック実装。
+//
+// 戻り値:
+//   - []models.BlogData: モックの戻り値設定に従う全ブログデータの一覧
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogRepository) FetchBlogs() ([]models.BlogData, error) {
 	args := m.Called()
 	if args.Get(0) != nil {
@@ -21,6 +25,13 @@ func (m *MockBlogRepository) FetchBlogs() ([]models.BlogData, error) {
 }
 
 // FetchBlogsByUserId は BlogRepository.FetchBlogsByUserId のモック実装。
+//
+// 引数:
+//   - userId: 取得対象のユーザーID
+//
+// 戻り値:
+//   - []models.BlogData: モックの戻り値設定に従うブログデータの一覧
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogRepository) FetchBlogsByUserId(userId string) ([]models.BlogData, error) {
 	args := m.Called(userId)
 	if args.Get(0) != nil {
@@ -30,6 +41,13 @@ func (m *MockBlogRepository) FetchBlogsByUserId(userId string) ([]models.BlogDat
 }
 
 // FetchBlogById は BlogRepository.FetchBlogById のモック実装。
+//
+// 引数:
+//   - id: 取得対象のブログID
+//
+// 戻り値:
+//   - *models.BlogData: モックの戻り値設定に従うブログデータ
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogRepository) FetchBlogById(id string) (*models.BlogData, error) {
 	args := m.Called(id)
 	if args.Get(0) != nil {
@@ -39,6 +57,18 @@ func (m *MockBlogRepository) FetchBlogById(id string) (*models.BlogData, error) 
 }
 
 // CreateBlog は BlogRepository.CreateBlog のモック実装。
+//
+// 引数:
+//   - userId: 作成者のユーザーID
+//   - title: ブログのタイトル
+//   - githubUrl: 関連する GitHub の URL
+//   - category: ブログのカテゴリ
+//   - description: ブログの説明
+//   - tags: ブログのタグ
+//
+// 戻り値:
+//   - *models.BlogData: モックの戻り値設定に従う作成後のブログデータ
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogRepository) CreateBlog(userId, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	args := m.Called(userId, title, githubUrl, category, description, tags)
 	if args.Get(0) != nil {
@@ -48,6 +78,18 @@ func (m *MockBlogRepository) CreateBlog(userId, title, githubUrl, category, desc
 }
 
 // UpdateBlog は BlogRepository.UpdateBlog のモック実装。
+//
+// 引数:
+//   - id: 更新対象のブログID
+//   - title: 更新後のタイトル
+//   - githubUrl: 更新後の GitHub の URL
+//   - category: 更新後のカテゴリ
+//   - description: 更新後の説明
+//   - tags: 更新後のタグ
+//
+// 戻り値:
+//   - *models.BlogData: モックの戻り値設定に従う更新後のブログデータ
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogRepository) UpdateBlog(id, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	args := m.Called(id, title, githubUrl, category, description, tags)
 	if args.Get(0) != nil {
@@ -57,12 +99,22 @@ func (m *MockBlogRepository) UpdateBlog(id, title, githubUrl, category, descript
 }
 
 // DeleteBlog は BlogRepository.DeleteBlog のモック実装。
+//
+// 引数:
+//   - id: 削除対象のブログID
+//
+// 戻り値:
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogRepository) DeleteBlog(id string) error {
 	args := m.Called(id)
 	return args.Error(0)
 }
 
 // FetchBlogCategories は BlogRepository.FetchBlogCategories のモック実装。
+//
+// 戻り値:
+//   - []string: モックの戻り値設定に従うカテゴリ一覧
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogRepository) FetchBlogCategories() ([]string, error) {
 	args := m.Called()
 	if args.Get(0) != nil {
@@ -72,6 +124,10 @@ func (m *MockBlogRepository) FetchBlogCategories() ([]string, error) {
 }
 
 // FetchBlogTags は BlogRepository.FetchBlogTags のモック実装。
+//
+// 戻り値:
+//   - []string: モックの戻り値設定に従うタグ一覧
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogRepository) FetchBlogTags() ([]string, error) {
 	args := m.Called()
 	if args.Get(0) != nil {
@@ -81,6 +137,13 @@ func (m *MockBlogRepository) FetchBlogTags() ([]string, error) {
 }
 
 // FetchBlogPopular は BlogRepository.FetchBlogPopular のモック実装。
+//
+// 引数:
+//   - count: 取得する件数
+//
+// 戻り値:
+//   - []models.BlogData: モックの戻り値設定に従う人気ブログデータの一覧
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogRepository) FetchBlogPopular(count int) ([]models.BlogData, error) {
 	args := m.Called(count)
 	if args.Get(0) != nil {

--- a/backend/repositories/blogs/blogs_mock.go
+++ b/backend/repositories/blogs/blogs_mock.go
@@ -6,10 +6,12 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// MockBlogRepository は BlogRepository のテスト用モック。
 type MockBlogRepository struct {
 	mock.Mock
 }
 
+// FetchBlogs は BlogRepository.FetchBlogs のモック実装。
 func (m *MockBlogRepository) FetchBlogs() ([]models.BlogData, error) {
 	args := m.Called()
 	if args.Get(0) != nil {
@@ -18,6 +20,7 @@ func (m *MockBlogRepository) FetchBlogs() ([]models.BlogData, error) {
 	return nil, args.Error(1)
 }
 
+// FetchBlogsByUserId は BlogRepository.FetchBlogsByUserId のモック実装。
 func (m *MockBlogRepository) FetchBlogsByUserId(userId string) ([]models.BlogData, error) {
 	args := m.Called(userId)
 	if args.Get(0) != nil {
@@ -26,6 +29,7 @@ func (m *MockBlogRepository) FetchBlogsByUserId(userId string) ([]models.BlogDat
 	return nil, args.Error(1)
 }
 
+// FetchBlogById は BlogRepository.FetchBlogById のモック実装。
 func (m *MockBlogRepository) FetchBlogById(id string) (*models.BlogData, error) {
 	args := m.Called(id)
 	if args.Get(0) != nil {
@@ -34,6 +38,7 @@ func (m *MockBlogRepository) FetchBlogById(id string) (*models.BlogData, error) 
 	return nil, args.Error(1)
 }
 
+// CreateBlog は BlogRepository.CreateBlog のモック実装。
 func (m *MockBlogRepository) CreateBlog(userId, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	args := m.Called(userId, title, githubUrl, category, description, tags)
 	if args.Get(0) != nil {
@@ -42,6 +47,7 @@ func (m *MockBlogRepository) CreateBlog(userId, title, githubUrl, category, desc
 	return nil, args.Error(1)
 }
 
+// UpdateBlog は BlogRepository.UpdateBlog のモック実装。
 func (m *MockBlogRepository) UpdateBlog(id, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	args := m.Called(id, title, githubUrl, category, description, tags)
 	if args.Get(0) != nil {
@@ -50,11 +56,13 @@ func (m *MockBlogRepository) UpdateBlog(id, title, githubUrl, category, descript
 	return nil, args.Error(1)
 }
 
+// DeleteBlog は BlogRepository.DeleteBlog のモック実装。
 func (m *MockBlogRepository) DeleteBlog(id string) error {
 	args := m.Called(id)
 	return args.Error(0)
 }
 
+// FetchBlogCategories は BlogRepository.FetchBlogCategories のモック実装。
 func (m *MockBlogRepository) FetchBlogCategories() ([]string, error) {
 	args := m.Called()
 	if args.Get(0) != nil {
@@ -63,6 +71,7 @@ func (m *MockBlogRepository) FetchBlogCategories() ([]string, error) {
 	return nil, args.Error(1)
 }
 
+// FetchBlogTags は BlogRepository.FetchBlogTags のモック実装。
 func (m *MockBlogRepository) FetchBlogTags() ([]string, error) {
 	args := m.Called()
 	if args.Get(0) != nil {
@@ -71,6 +80,7 @@ func (m *MockBlogRepository) FetchBlogTags() ([]string, error) {
 	return nil, args.Error(1)
 }
 
+// FetchBlogPopular は BlogRepository.FetchBlogPopular のモック実装。
 func (m *MockBlogRepository) FetchBlogPopular(count int) ([]models.BlogData, error) {
 	args := m.Called(count)
 	if args.Get(0) != nil {

--- a/backend/repositories/blogs/blogs_testing_setup.go
+++ b/backend/repositories/blogs/blogs_testing_setup.go
@@ -9,6 +9,9 @@ import (
 )
 
 // SetupTest はテストの前に環境変数を読み込み、ログ設定を初期化します
+//
+// 引数:
+//   - t: テストコンテキスト（初期化失敗時に t.Fatalf で停止する）
 func SetupTest(t *testing.T) {
 	// 環境変数の読み込み
 	err := godotenv.Load("../../../.env.test")

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -26,6 +26,9 @@ import (
 )
 
 // SetupRoutes は依存を初期化し、API エンドポイントのルーティングを設定する。
+//
+// 引数:
+//   - e: ルーティングを設定する対象の Echo インスタンス
 func SetupRoutes(e *echo.Echo) {
 	// ヘルスチェックエンドポイントの追加
 	e.GET("/", func(c echo.Context) error {

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -25,7 +25,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// ルーティングを設定する関数
+// SetupRoutes は依存を初期化し、API エンドポイントのルーティングを設定する。
 func SetupRoutes(e *echo.Echo) {
 	// ヘルスチェックエンドポイントの追加
 	e.GET("/", func(c echo.Context) error {

--- a/backend/services/auth/auth.go
+++ b/backend/services/auth/auth.go
@@ -6,7 +6,7 @@ import (
 	"net/mail"
 )
 
-// ログイン処理を行う
+// Login はメール/パスワードを検証してログイン処理を行う。
 func (r *AuthServiceImpl) Login(email, password string) error {
 	log.Println("Logging in...")
 

--- a/backend/services/auth/auth.go
+++ b/backend/services/auth/auth.go
@@ -7,6 +7,13 @@ import (
 )
 
 // Login はメール/パスワードを検証してログイン処理を行う。
+//
+// 引数:
+//   - email: 検証対象のメールアドレス
+//   - password: 検証対象のパスワード
+//
+// 戻り値:
+//   - error: バリデーションに失敗した場合のエラー
 func (r *AuthServiceImpl) Login(email, password string) error {
 	log.Println("Logging in...")
 

--- a/backend/services/auth/auth_impl.go
+++ b/backend/services/auth/auth_impl.go
@@ -1,13 +1,16 @@
 package services_auth
 
-// AuthServiceインターフェース
+// AuthService は認証処理を提供するサービスインターフェース。
 type AuthService interface {
+	// Login はメール/パスワードを検証してログイン処理を行う。
 	Login(email, password string) error
 }
+
+// AuthServiceImpl は AuthService の実装。
 type AuthServiceImpl struct {
 }
 
-// AuthServiceインターフェースを実装したAuthServiceImplのポインタを返す
+// NewAuthService は AuthService インターフェースを実装した AuthServiceImpl を生成する。
 func NewAuthService() AuthService {
 	return &AuthServiceImpl{}
 }

--- a/backend/services/auth/auth_impl.go
+++ b/backend/services/auth/auth_impl.go
@@ -3,6 +3,13 @@ package services_auth
 // AuthService は認証処理を提供するサービスインターフェース。
 type AuthService interface {
 	// Login はメール/パスワードを検証してログイン処理を行う。
+	//
+	// 引数:
+	//   - email: 検証対象のメールアドレス
+	//   - password: 検証対象のパスワード
+	//
+	// 戻り値:
+	//   - error: バリデーションに失敗した場合のエラー
 	Login(email, password string) error
 }
 
@@ -11,6 +18,9 @@ type AuthServiceImpl struct {
 }
 
 // NewAuthService は AuthService インターフェースを実装した AuthServiceImpl を生成する。
+//
+// 戻り値:
+//   - AuthService: 生成された認証サービス
 func NewAuthService() AuthService {
 	return &AuthServiceImpl{}
 }

--- a/backend/services/auth/auth_mock.go
+++ b/backend/services/auth/auth_mock.go
@@ -2,11 +2,12 @@ package services_auth
 
 import "github.com/stretchr/testify/mock"
 
+// MockAuthService は AuthService のテスト用モック。
 type MockAuthService struct {
 	mock.Mock
 }
 
-// Login メソッドのモック実装
+// Login は AuthService.Login のテスト用モック。
 func (m *MockAuthService) Login(email, password string) error {
 	args := m.Called(email, password)
 	return args.Error(0)

--- a/backend/services/auth/auth_mock.go
+++ b/backend/services/auth/auth_mock.go
@@ -8,6 +8,13 @@ type MockAuthService struct {
 }
 
 // Login は AuthService.Login のテスト用モック。
+//
+// 引数:
+//   - email: 検証対象のメールアドレス
+//   - password: 検証対象のパスワード
+//
+// 戻り値:
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockAuthService) Login(email, password string) error {
 	args := m.Called(email, password)
 	return args.Error(0)

--- a/backend/services/blog_comments/blog_comments.go
+++ b/backend/services/blog_comments/blog_comments.go
@@ -6,7 +6,7 @@ import (
 	"log"
 )
 
-// 指定されたブログIDに一致するコメントデータを取得する
+// FetchCommentsByBlogId は指定されたブログIDに一致するコメントデータを取得する。
 func (s *CommentServiceImpl) FetchCommentsByBlogId(blogId string) ([]models.BlogCommentsData, error) {
 	log.Printf("FetchCommentsByBlogId start...")
 
@@ -28,7 +28,7 @@ func (s *CommentServiceImpl) FetchCommentsByBlogId(blogId string) ([]models.Blog
 	return comments, nil
 }
 
-// コメントデータを新規作成する
+// CreateComment はコメントデータを新規作成する。
 func (s *CommentServiceImpl) CreateComment(blogId, guestUser, comment string) (*models.BlogCommentsData, error) {
 	log.Printf("CreateComment start...")
 

--- a/backend/services/blog_comments/blog_comments.go
+++ b/backend/services/blog_comments/blog_comments.go
@@ -7,6 +7,13 @@ import (
 )
 
 // FetchCommentsByBlogId は指定されたブログIDに一致するコメントデータを取得する。
+//
+// 引数:
+//   - blogId: 取得対象のブログID
+//
+// 戻り値:
+//   - []models.BlogCommentsData: 取得したコメントデータの一覧
+//   - error: 取得に失敗した場合のエラー
 func (s *CommentServiceImpl) FetchCommentsByBlogId(blogId string) ([]models.BlogCommentsData, error) {
 	log.Printf("FetchCommentsByBlogId start...")
 
@@ -29,6 +36,15 @@ func (s *CommentServiceImpl) FetchCommentsByBlogId(blogId string) ([]models.Blog
 }
 
 // CreateComment はコメントデータを新規作成する。
+//
+// 引数:
+//   - blogId: コメント対象のブログID
+//   - guestUser: コメントを投稿するゲストユーザー名
+//   - comment: コメント本文
+//
+// 戻り値:
+//   - *models.BlogCommentsData: 作成されたコメントデータ
+//   - error: 作成に失敗した場合のエラー
 func (s *CommentServiceImpl) CreateComment(blogId, guestUser, comment string) (*models.BlogCommentsData, error) {
 	log.Printf("CreateComment start...")
 

--- a/backend/services/blog_comments/blog_comments_impl.go
+++ b/backend/services/blog_comments/blog_comments_impl.go
@@ -8,8 +8,24 @@ import (
 // CommentService はコメントに関する処理を提供するサービスインターフェース。
 type CommentService interface {
 	// FetchCommentsByBlogId は指定されたブログIDに一致するコメントデータを取得する。
+	//
+	// 引数:
+	//   - blogId: 取得対象のブログID
+	//
+	// 戻り値:
+	//   - []models.BlogCommentsData: 取得したコメントデータの一覧
+	//   - error: 取得に失敗した場合のエラー
 	FetchCommentsByBlogId(blogId string) ([]models.BlogCommentsData, error)
 	// CreateComment はコメントデータを新規作成する。
+	//
+	// 引数:
+	//   - blogId: コメント対象のブログID
+	//   - guestUser: コメントを投稿するゲストユーザー名
+	//   - comment: コメント本文
+	//
+	// 戻り値:
+	//   - *models.BlogCommentsData: 作成されたコメントデータ
+	//   - error: 作成に失敗した場合のエラー
 	CreateComment(blogId, guestUser, comment string) (*models.BlogCommentsData, error)
 }
 
@@ -19,6 +35,12 @@ type CommentServiceImpl struct {
 }
 
 // NewCommentService は CommentService インターフェースを実装した CommentServiceImpl を生成する。
+//
+// 引数:
+//   - commentRepository: コメントデータへのアクセスを担うリポジトリ
+//
+// 戻り値:
+//   - CommentService: 生成されたコメントサービス
 func NewCommentService(
 	commentRepository repositories_comments.CommentRepository,
 ) CommentService {

--- a/backend/services/blog_comments/blog_comments_impl.go
+++ b/backend/services/blog_comments/blog_comments_impl.go
@@ -5,17 +5,20 @@ import (
 	repositories_comments "backend/repositories/blog_comments"
 )
 
-// CommentServiceインターフェース
+// CommentService はコメントに関する処理を提供するサービスインターフェース。
 type CommentService interface {
+	// FetchCommentsByBlogId は指定されたブログIDに一致するコメントデータを取得する。
 	FetchCommentsByBlogId(blogId string) ([]models.BlogCommentsData, error)
+	// CreateComment はコメントデータを新規作成する。
 	CreateComment(blogId, guestUser, comment string) (*models.BlogCommentsData, error)
 }
 
+// CommentServiceImpl は CommentService の実装。
 type CommentServiceImpl struct {
 	CommentRepository repositories_comments.CommentRepository
 }
 
-// CommentServiceインターフェースを実装したCommentServiceImplのポインタを返す
+// NewCommentService は CommentService インターフェースを実装した CommentServiceImpl を生成する。
 func NewCommentService(
 	commentRepository repositories_comments.CommentRepository,
 ) CommentService {

--- a/backend/services/blog_comments/blog_comments_mock.go
+++ b/backend/services/blog_comments/blog_comments_mock.go
@@ -12,6 +12,13 @@ type MockCommentService struct {
 }
 
 // FetchCommentsByBlogId は CommentService.FetchCommentsByBlogId のテスト用モック。
+//
+// 引数:
+//   - blogId: 取得対象のブログID
+//
+// 戻り値:
+//   - []models.BlogCommentsData: モックの戻り値設定に従うコメントデータの一覧
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockCommentService) FetchCommentsByBlogId(blogId string) ([]models.BlogCommentsData, error) {
 	args := m.Called(blogId)
 	if args.Get(0) == nil {
@@ -21,6 +28,15 @@ func (m *MockCommentService) FetchCommentsByBlogId(blogId string) ([]models.Blog
 }
 
 // CreateComment は CommentService.CreateComment のテスト用モック。
+//
+// 引数:
+//   - blogId: コメント対象のブログID
+//   - guestUser: コメントを投稿するゲストユーザー名
+//   - comment: コメント本文
+//
+// 戻り値:
+//   - *models.BlogCommentsData: モックの戻り値設定に従う作成済みコメントデータ
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockCommentService) CreateComment(blogId, guestUser, comment string) (*models.BlogCommentsData, error) {
 	args := m.Called(blogId, guestUser, comment)
 	if args.Get(0) == nil {

--- a/backend/services/blog_comments/blog_comments_mock.go
+++ b/backend/services/blog_comments/blog_comments_mock.go
@@ -6,10 +6,12 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// MockCommentService は CommentService のテスト用モック。
 type MockCommentService struct {
 	mock.Mock
 }
 
+// FetchCommentsByBlogId は CommentService.FetchCommentsByBlogId のテスト用モック。
 func (m *MockCommentService) FetchCommentsByBlogId(blogId string) ([]models.BlogCommentsData, error) {
 	args := m.Called(blogId)
 	if args.Get(0) == nil {
@@ -18,6 +20,7 @@ func (m *MockCommentService) FetchCommentsByBlogId(blogId string) ([]models.Blog
 	return args.Get(0).([]models.BlogCommentsData), args.Error(1)
 }
 
+// CreateComment は CommentService.CreateComment のテスト用モック。
 func (m *MockCommentService) CreateComment(blogId, guestUser, comment string) (*models.BlogCommentsData, error) {
 	args := m.Called(blogId, guestUser, comment)
 	if args.Get(0) == nil {

--- a/backend/services/blog_likes/blog_likes.go
+++ b/backend/services/blog_likes/blog_likes.go
@@ -7,6 +7,13 @@ import (
 )
 
 // FetchBlogLikesByVisitId は VisitId に紐づくいいねデータを取得する。
+//
+// 引数:
+//   - visitId: 取得対象の訪問者ID
+//
+// 戻り値:
+//   - []models.BlogLikesData: 取得したいいねデータの一覧
+//   - error: 取得に失敗した場合のエラー
 func (s *BlogLikeServiceImpl) FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikesData, error) {
 	log.Println("FetchBlogLikesByVisitId start...")
 
@@ -28,6 +35,14 @@ func (s *BlogLikeServiceImpl) FetchBlogLikesByVisitId(visitId string) ([]models.
 }
 
 // IsBlogLiked はいいねが存在するかを確認する。
+//
+// 引数:
+//   - blogId: 確認対象のブログID
+//   - visitId: 確認対象の訪問者ID
+//
+// 戻り値:
+//   - bool: いいねが存在する場合は true
+//   - error: 確認に失敗した場合のエラー
 func (s *BlogLikeServiceImpl) IsBlogLiked(blogId, visitId string) (bool, error) {
 	log.Println("IsBlogLiked start...")
 
@@ -48,6 +63,14 @@ func (s *BlogLikeServiceImpl) IsBlogLiked(blogId, visitId string) (bool, error) 
 }
 
 // CreateBlogLike はいいねデータを作成する。
+//
+// 引数:
+//   - blogId: いいね対象のブログID
+//   - visitId: いいねする訪問者ID
+//
+// 戻り値:
+//   - *models.BlogLikesData: 作成されたいいねデータ
+//   - error: 作成に失敗した場合のエラー
 func (s *BlogLikeServiceImpl) CreateBlogLike(blogId, visitId string) (*models.BlogLikesData, error) {
 	log.Println("CreateBlogLike start...")
 
@@ -75,6 +98,13 @@ func (s *BlogLikeServiceImpl) CreateBlogLike(blogId, visitId string) (*models.Bl
 }
 
 // DeleteBlogLike はいいねデータを削除する。
+//
+// 引数:
+//   - blogId: 削除対象のブログID
+//   - visitId: 削除対象の訪問者ID
+//
+// 戻り値:
+//   - error: 削除に失敗した場合のエラー
 func (s *BlogLikeServiceImpl) DeleteBlogLike(blogId, visitId string) error {
 	log.Println("DeleteBlogLike start...")
 

--- a/backend/services/blog_likes/blog_likes.go
+++ b/backend/services/blog_likes/blog_likes.go
@@ -6,7 +6,7 @@ import (
 	"log"
 )
 
-// VisitIdに紐づくいいねデータを取得
+// FetchBlogLikesByVisitId は VisitId に紐づくいいねデータを取得する。
 func (s *BlogLikeServiceImpl) FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikesData, error) {
 	log.Println("FetchBlogLikesByVisitId start...")
 
@@ -27,7 +27,7 @@ func (s *BlogLikeServiceImpl) FetchBlogLikesByVisitId(visitId string) ([]models.
 	return blogLikes, nil
 }
 
-// いいね存在するか確認
+// IsBlogLiked はいいねが存在するかを確認する。
 func (s *BlogLikeServiceImpl) IsBlogLiked(blogId, visitId string) (bool, error) {
 	log.Println("IsBlogLiked start...")
 
@@ -47,7 +47,7 @@ func (s *BlogLikeServiceImpl) IsBlogLiked(blogId, visitId string) (bool, error) 
 	return isLiked, nil
 }
 
-// いいねデータの作成
+// CreateBlogLike はいいねデータを作成する。
 func (s *BlogLikeServiceImpl) CreateBlogLike(blogId, visitId string) (*models.BlogLikesData, error) {
 	log.Println("CreateBlogLike start...")
 
@@ -74,7 +74,7 @@ func (s *BlogLikeServiceImpl) CreateBlogLike(blogId, visitId string) (*models.Bl
 	return blogLike, nil
 }
 
-// いいねデータの削除
+// DeleteBlogLike はいいねデータを削除する。
 func (s *BlogLikeServiceImpl) DeleteBlogLike(blogId, visitId string) error {
 	log.Println("DeleteBlogLike start...")
 

--- a/backend/services/blog_likes/blog_likes_impl.go
+++ b/backend/services/blog_likes/blog_likes_impl.go
@@ -5,19 +5,24 @@ import (
 	repositories_blogs_likes "backend/repositories/blog_likes"
 )
 
-// BlogLikeServiceインターフェース
+// BlogLikeService はいいねに関する処理を提供するサービスインターフェース。
 type BlogLikeService interface {
+	// FetchBlogLikesByVisitId は VisitId に紐づくいいねデータを取得する。
 	FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikesData, error)
+	// IsBlogLiked はいいねが存在するかを確認する。
 	IsBlogLiked(blogId, visitId string) (bool, error)
+	// CreateBlogLike はいいねデータを作成する。
 	CreateBlogLike(blogId, visitId string) (*models.BlogLikesData, error)
+	// DeleteBlogLike はいいねデータを削除する。
 	DeleteBlogLike(blogId, visitId string) error
 }
 
+// BlogLikeServiceImpl は BlogLikeService の実装。
 type BlogLikeServiceImpl struct {
 	BlogLikeRepository repositories_blogs_likes.BlogLikeRepository
 }
 
-// BlogLikeServiceインターフェースを実装したBlogLikeServiceImplのポインタを返す
+// NewBlogLikeService は BlogLikeService インターフェースを実装した BlogLikeServiceImpl を生成する。
 func NewBlogLikeService(
 	blogLikeRepository repositories_blogs_likes.BlogLikeRepository,
 ) BlogLikeService {

--- a/backend/services/blog_likes/blog_likes_impl.go
+++ b/backend/services/blog_likes/blog_likes_impl.go
@@ -8,12 +8,42 @@ import (
 // BlogLikeService はいいねに関する処理を提供するサービスインターフェース。
 type BlogLikeService interface {
 	// FetchBlogLikesByVisitId は VisitId に紐づくいいねデータを取得する。
+	//
+	// 引数:
+	//   - visitId: 取得対象の訪問者ID
+	//
+	// 戻り値:
+	//   - []models.BlogLikesData: 取得したいいねデータの一覧
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikesData, error)
 	// IsBlogLiked はいいねが存在するかを確認する。
+	//
+	// 引数:
+	//   - blogId: 確認対象のブログID
+	//   - visitId: 確認対象の訪問者ID
+	//
+	// 戻り値:
+	//   - bool: いいねが存在する場合は true
+	//   - error: 確認に失敗した場合のエラー
 	IsBlogLiked(blogId, visitId string) (bool, error)
 	// CreateBlogLike はいいねデータを作成する。
+	//
+	// 引数:
+	//   - blogId: いいね対象のブログID
+	//   - visitId: いいねする訪問者ID
+	//
+	// 戻り値:
+	//   - *models.BlogLikesData: 作成されたいいねデータ
+	//   - error: 作成に失敗した場合のエラー
 	CreateBlogLike(blogId, visitId string) (*models.BlogLikesData, error)
 	// DeleteBlogLike はいいねデータを削除する。
+	//
+	// 引数:
+	//   - blogId: 削除対象のブログID
+	//   - visitId: 削除対象の訪問者ID
+	//
+	// 戻り値:
+	//   - error: 削除に失敗した場合のエラー
 	DeleteBlogLike(blogId, visitId string) error
 }
 
@@ -23,6 +53,12 @@ type BlogLikeServiceImpl struct {
 }
 
 // NewBlogLikeService は BlogLikeService インターフェースを実装した BlogLikeServiceImpl を生成する。
+//
+// 引数:
+//   - blogLikeRepository: いいねデータへのアクセスを担うリポジトリ
+//
+// 戻り値:
+//   - BlogLikeService: 生成されたいいねサービス
 func NewBlogLikeService(
 	blogLikeRepository repositories_blogs_likes.BlogLikeRepository,
 ) BlogLikeService {

--- a/backend/services/blog_likes/blog_likes_mock.go
+++ b/backend/services/blog_likes/blog_likes_mock.go
@@ -6,10 +6,12 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// MockBlogLikeService は BlogLikeService のテスト用モック。
 type MockBlogLikeService struct {
 	mock.Mock
 }
 
+// FetchBlogLikesByVisitId は BlogLikeService.FetchBlogLikesByVisitId のテスト用モック。
 func (m *MockBlogLikeService) FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikesData, error) {
 	args := m.Called(visitId)
 	if args.Get(0) != nil {
@@ -18,11 +20,13 @@ func (m *MockBlogLikeService) FetchBlogLikesByVisitId(visitId string) ([]models.
 	return nil, args.Error(1)
 }
 
+// IsBlogLiked は BlogLikeService.IsBlogLiked のテスト用モック。
 func (m *MockBlogLikeService) IsBlogLiked(blogId, visitId string) (bool, error) {
 	args := m.Called(blogId, visitId)
 	return args.Bool(0), args.Error(1)
 }
 
+// CreateBlogLike は BlogLikeService.CreateBlogLike のテスト用モック。
 func (m *MockBlogLikeService) CreateBlogLike(blogId, visitId string) (*models.BlogLikesData, error) {
 	args := m.Called(blogId, visitId)
 	if args.Get(0) != nil {
@@ -31,6 +35,7 @@ func (m *MockBlogLikeService) CreateBlogLike(blogId, visitId string) (*models.Bl
 	return nil, args.Error(1)
 }
 
+// DeleteBlogLike は BlogLikeService.DeleteBlogLike のテスト用モック。
 func (m *MockBlogLikeService) DeleteBlogLike(blogId, visitId string) error {
 	args := m.Called(blogId, visitId)
 	return args.Error(0)

--- a/backend/services/blog_likes/blog_likes_mock.go
+++ b/backend/services/blog_likes/blog_likes_mock.go
@@ -12,6 +12,13 @@ type MockBlogLikeService struct {
 }
 
 // FetchBlogLikesByVisitId は BlogLikeService.FetchBlogLikesByVisitId のテスト用モック。
+//
+// 引数:
+//   - visitId: 取得対象の訪問者ID
+//
+// 戻り値:
+//   - []models.BlogLikesData: モックの戻り値設定に従ういいねデータの一覧
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogLikeService) FetchBlogLikesByVisitId(visitId string) ([]models.BlogLikesData, error) {
 	args := m.Called(visitId)
 	if args.Get(0) != nil {
@@ -21,12 +28,28 @@ func (m *MockBlogLikeService) FetchBlogLikesByVisitId(visitId string) ([]models.
 }
 
 // IsBlogLiked は BlogLikeService.IsBlogLiked のテスト用モック。
+//
+// 引数:
+//   - blogId: 確認対象のブログID
+//   - visitId: 確認対象の訪問者ID
+//
+// 戻り値:
+//   - bool: モックの戻り値設定に従ういいね存在有無
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogLikeService) IsBlogLiked(blogId, visitId string) (bool, error) {
 	args := m.Called(blogId, visitId)
 	return args.Bool(0), args.Error(1)
 }
 
 // CreateBlogLike は BlogLikeService.CreateBlogLike のテスト用モック。
+//
+// 引数:
+//   - blogId: いいね対象のブログID
+//   - visitId: いいねする訪問者ID
+//
+// 戻り値:
+//   - *models.BlogLikesData: モックの戻り値設定に従う作成済みいいねデータ
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogLikeService) CreateBlogLike(blogId, visitId string) (*models.BlogLikesData, error) {
 	args := m.Called(blogId, visitId)
 	if args.Get(0) != nil {
@@ -36,6 +59,13 @@ func (m *MockBlogLikeService) CreateBlogLike(blogId, visitId string) (*models.Bl
 }
 
 // DeleteBlogLike は BlogLikeService.DeleteBlogLike のテスト用モック。
+//
+// 引数:
+//   - blogId: 削除対象のブログID
+//   - visitId: 削除対象の訪問者ID
+//
+// 戻り値:
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogLikeService) DeleteBlogLike(blogId, visitId string) error {
 	args := m.Called(blogId, visitId)
 	return args.Error(0)

--- a/backend/services/blog_users/blog_users.go
+++ b/backend/services/blog_users/blog_users.go
@@ -8,7 +8,7 @@ import (
 	"net/mail"
 )
 
-// 指定されたメールアドレスとパスワードでユーザーを取得する。
+// FetchUserByEmailAndPassword は指定されたメールアドレスとパスワードでユーザーを取得する。
 // ユーザーが見つからない場合、エラーを返す。
 func (s *UserServiceImpl) FetchUserByEmailAndPassword(email, password string) (*models.BlogUsersData, error) {
 	// バリデーション：emailとpasswordが空でないことを確認
@@ -38,7 +38,7 @@ func (s *UserServiceImpl) FetchUserByEmailAndPassword(email, password string) (*
 	return user, nil
 }
 
-// 指定されたIDに一致するユーザーを取得する
+// FetchUserById は指定されたIDに一致するユーザーを取得する。
 func (s *UserServiceImpl) FetchUserById(id string) (*models.BlogUsersData, error) {
 	log.Println("Fetching user by id")
 
@@ -60,7 +60,7 @@ func (s *UserServiceImpl) FetchUserById(id string) (*models.BlogUsersData, error
 	return user, nil
 }
 
-// 指定されたIDに一致するユーザーを更新する
+// UpdateUser は指定されたIDに一致するユーザーを更新する。
 func (s *UserServiceImpl) UpdateUser(id, name, email, password, newPassword string) (*models.BlogUsersData, error) {
 	log.Println("Updating user")
 

--- a/backend/services/blog_users/blog_users.go
+++ b/backend/services/blog_users/blog_users.go
@@ -10,6 +10,14 @@ import (
 
 // FetchUserByEmailAndPassword は指定されたメールアドレスとパスワードでユーザーを取得する。
 // ユーザーが見つからない場合、エラーを返す。
+//
+// 引数:
+//   - email: 取得対象のメールアドレス
+//   - password: 取得対象のパスワード
+//
+// 戻り値:
+//   - *models.BlogUsersData: 取得したユーザーデータ
+//   - error: 取得に失敗した場合のエラー
 func (s *UserServiceImpl) FetchUserByEmailAndPassword(email, password string) (*models.BlogUsersData, error) {
 	// バリデーション：emailとpasswordが空でないことを確認
 	if email == "" || password == "" {
@@ -39,6 +47,13 @@ func (s *UserServiceImpl) FetchUserByEmailAndPassword(email, password string) (*
 }
 
 // FetchUserById は指定されたIDに一致するユーザーを取得する。
+//
+// 引数:
+//   - id: 取得対象のユーザーID
+//
+// 戻り値:
+//   - *models.BlogUsersData: 取得したユーザーデータ
+//   - error: 取得に失敗した場合のエラー
 func (s *UserServiceImpl) FetchUserById(id string) (*models.BlogUsersData, error) {
 	log.Println("Fetching user by id")
 
@@ -61,6 +76,17 @@ func (s *UserServiceImpl) FetchUserById(id string) (*models.BlogUsersData, error
 }
 
 // UpdateUser は指定されたIDに一致するユーザーを更新する。
+//
+// 引数:
+//   - id: 更新対象のユーザーID
+//   - name: 更新後のユーザー名
+//   - email: 更新後のメールアドレス
+//   - password: 本人確認用の現在のパスワード
+//   - newPassword: 更新後の新しいパスワード
+//
+// 戻り値:
+//   - *models.BlogUsersData: 更新後のユーザーデータ
+//   - error: 更新に失敗した場合のエラー
 func (s *UserServiceImpl) UpdateUser(id, name, email, password, newPassword string) (*models.BlogUsersData, error) {
 	log.Println("Updating user")
 

--- a/backend/services/blog_users/blog_users_impl.go
+++ b/backend/services/blog_users/blog_users_impl.go
@@ -5,17 +5,22 @@ import (
 	repositories_blog_users "backend/repositories/blog_users"
 )
 
-// UserServiceインターフェース
+// UserService はユーザーに関する処理を提供するサービスインターフェース。
 type UserService interface {
+	// FetchUserByEmailAndPassword は指定されたメールアドレスとパスワードでユーザーを取得する。
 	FetchUserByEmailAndPassword(email, password string) (*models.BlogUsersData, error)
+	// FetchUserById は指定されたIDに一致するユーザーを取得する。
 	FetchUserById(id string) (*models.BlogUsersData, error)
+	// UpdateUser は指定されたIDに一致するユーザーを更新する。
 	UpdateUser(id, name, email, password, newPassword string) (*models.BlogUsersData, error)
 }
+
+// UserServiceImpl は UserService の実装。
 type UserServiceImpl struct {
 	UserRepository repositories_blog_users.BlogUsersRepository
 }
 
-// UserServiceインターフェースを実装したUserServiceImplのポインタを返す
+// NewUserService は UserService インターフェースを実装した UserServiceImpl を生成する。
 func NewUserService(
 	userRepository repositories_blog_users.BlogUsersRepository,
 ) UserService {

--- a/backend/services/blog_users/blog_users_impl.go
+++ b/backend/services/blog_users/blog_users_impl.go
@@ -8,10 +8,36 @@ import (
 // UserService はユーザーに関する処理を提供するサービスインターフェース。
 type UserService interface {
 	// FetchUserByEmailAndPassword は指定されたメールアドレスとパスワードでユーザーを取得する。
+	//
+	// 引数:
+	//   - email: 取得対象のメールアドレス
+	//   - password: 取得対象のパスワード
+	//
+	// 戻り値:
+	//   - *models.BlogUsersData: 取得したユーザーデータ
+	//   - error: 取得に失敗した場合のエラー
 	FetchUserByEmailAndPassword(email, password string) (*models.BlogUsersData, error)
 	// FetchUserById は指定されたIDに一致するユーザーを取得する。
+	//
+	// 引数:
+	//   - id: 取得対象のユーザーID
+	//
+	// 戻り値:
+	//   - *models.BlogUsersData: 取得したユーザーデータ
+	//   - error: 取得に失敗した場合のエラー
 	FetchUserById(id string) (*models.BlogUsersData, error)
 	// UpdateUser は指定されたIDに一致するユーザーを更新する。
+	//
+	// 引数:
+	//   - id: 更新対象のユーザーID
+	//   - name: 更新後のユーザー名
+	//   - email: 更新後のメールアドレス
+	//   - password: 本人確認用の現在のパスワード
+	//   - newPassword: 更新後の新しいパスワード
+	//
+	// 戻り値:
+	//   - *models.BlogUsersData: 更新後のユーザーデータ
+	//   - error: 更新に失敗した場合のエラー
 	UpdateUser(id, name, email, password, newPassword string) (*models.BlogUsersData, error)
 }
 
@@ -21,6 +47,12 @@ type UserServiceImpl struct {
 }
 
 // NewUserService は UserService インターフェースを実装した UserServiceImpl を生成する。
+//
+// 引数:
+//   - userRepository: ユーザーデータへのアクセスを担うリポジトリ
+//
+// 戻り値:
+//   - UserService: 生成されたユーザーサービス
 func NewUserService(
 	userRepository repositories_blog_users.BlogUsersRepository,
 ) UserService {

--- a/backend/services/blog_users/blog_users_mock.go
+++ b/backend/services/blog_users/blog_users_mock.go
@@ -12,6 +12,14 @@ type MockUserService struct {
 }
 
 // FetchUserByEmailAndPassword は UserService.FetchUserByEmailAndPassword のテスト用モック。
+//
+// 引数:
+//   - email: 取得対象のメールアドレス
+//   - password: 取得対象のパスワード
+//
+// 戻り値:
+//   - *models.BlogUsersData: モックの戻り値設定に従うユーザーデータ
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockUserService) FetchUserByEmailAndPassword(email, password string) (*models.BlogUsersData, error) {
 	args := m.Called(email, password)
 	if args.Get(0) == nil {
@@ -21,6 +29,13 @@ func (m *MockUserService) FetchUserByEmailAndPassword(email, password string) (*
 }
 
 // FetchUserById は UserService.FetchUserById のテスト用モック。
+//
+// 引数:
+//   - id: 取得対象のユーザーID
+//
+// 戻り値:
+//   - *models.BlogUsersData: モックの戻り値設定に従うユーザーデータ
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockUserService) FetchUserById(id string) (*models.BlogUsersData, error) {
 	args := m.Called(id)
 	if args.Get(0) == nil {
@@ -30,6 +45,17 @@ func (m *MockUserService) FetchUserById(id string) (*models.BlogUsersData, error
 }
 
 // UpdateUser は UserService.UpdateUser のテスト用モック。
+//
+// 引数:
+//   - id: 更新対象のユーザーID
+//   - name: 更新後のユーザー名
+//   - email: 更新後のメールアドレス
+//   - password: 本人確認用の現在のパスワード
+//   - newPassword: 更新後の新しいパスワード
+//
+// 戻り値:
+//   - *models.BlogUsersData: モックの戻り値設定に従う更新後ユーザーデータ
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockUserService) UpdateUser(id, name, email, password, newPassword string) (*models.BlogUsersData, error) {
 	args := m.Called(id, name, email, password, newPassword)
 	if args.Get(0) == nil {

--- a/backend/services/blog_users/blog_users_mock.go
+++ b/backend/services/blog_users/blog_users_mock.go
@@ -6,10 +6,12 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// MockUserService は UserService のテスト用モック。
 type MockUserService struct {
 	mock.Mock
 }
 
+// FetchUserByEmailAndPassword は UserService.FetchUserByEmailAndPassword のテスト用モック。
 func (m *MockUserService) FetchUserByEmailAndPassword(email, password string) (*models.BlogUsersData, error) {
 	args := m.Called(email, password)
 	if args.Get(0) == nil {
@@ -18,6 +20,7 @@ func (m *MockUserService) FetchUserByEmailAndPassword(email, password string) (*
 	return args.Get(0).(*models.BlogUsersData), args.Error(1)
 }
 
+// FetchUserById は UserService.FetchUserById のテスト用モック。
 func (m *MockUserService) FetchUserById(id string) (*models.BlogUsersData, error) {
 	args := m.Called(id)
 	if args.Get(0) == nil {
@@ -26,6 +29,7 @@ func (m *MockUserService) FetchUserById(id string) (*models.BlogUsersData, error
 	return args.Get(0).(*models.BlogUsersData), args.Error(1)
 }
 
+// UpdateUser は UserService.UpdateUser のテスト用モック。
 func (m *MockUserService) UpdateUser(id, name, email, password, newPassword string) (*models.BlogUsersData, error) {
 	args := m.Called(id, name, email, password, newPassword)
 	if args.Get(0) == nil {

--- a/backend/services/blogs/blogs.go
+++ b/backend/services/blogs/blogs.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 )
 
-// 全ブログデータを取得する
+// FetchBlogs は全ブログデータを取得する。
 func (s *BlogServiceImpl) FetchBlogs() ([]models.BlogData, error) {
 	return s.BlogRepository.FetchBlogs()
 }
 
-// 指定されたユーザーIDに一致するブログデータを取得する
+// FetchBlogsByUserId は指定されたユーザーIDに一致するブログデータを取得する。
 func (s *BlogServiceImpl) FetchBlogsByUserId(userId string) ([]models.BlogData, error) {
 	logger.InfoLog.Printf("FetchBlogsByUserId start...")
 
@@ -35,7 +35,7 @@ func (s *BlogServiceImpl) FetchBlogsByUserId(userId string) ([]models.BlogData, 
 	return blogs, nil
 }
 
-// 指定されたIDに一致するブログデータを取得する
+// FetchBlogById は指定されたIDに一致するブログデータを取得する。
 func (s *BlogServiceImpl) FetchBlogById(id string) (*models.BlogData, error) {
 	logger.InfoLog.Printf("FetchBlogById start...")
 
@@ -57,7 +57,7 @@ func (s *BlogServiceImpl) FetchBlogById(id string) (*models.BlogData, error) {
 	return blog, nil
 }
 
-// ブログデータを作成する
+// CreateBlog はブログデータを作成する。
 func (s *BlogServiceImpl) CreateBlog(userId, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	logger.InfoLog.Printf("CreateBlog start...")
 
@@ -99,7 +99,7 @@ func (s *BlogServiceImpl) CreateBlog(userId, title, githubUrl, category, descrip
 	return blog, nil
 }
 
-// 指定されたIDに一致するブログデータを更新する
+// UpdateBlog は指定されたIDに一致するブログデータを更新する。
 func (s *BlogServiceImpl) UpdateBlog(id, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	logger.InfoLog.Printf("UpdateBlog start...")
 
@@ -141,7 +141,7 @@ func (s *BlogServiceImpl) UpdateBlog(id, title, githubUrl, category, description
 	return blog, nil
 }
 
-// 指定されたIDに一致するブログデータを削除する
+// DeleteBlog は指定されたIDに一致するブログデータを削除する。
 func (s *BlogServiceImpl) DeleteBlog(id string) error {
 	logger.InfoLog.Printf("DeleteBlog start...")
 
@@ -163,12 +163,12 @@ func (s *BlogServiceImpl) DeleteBlog(id string) error {
 	return nil
 }
 
-// ブログカテゴリを取得する
+// FetchBlogCategories はブログカテゴリを取得する。
 func (s *BlogServiceImpl) FetchBlogCategories() ([]string, error) {
 	return s.BlogRepository.FetchBlogCategories()
 }
 
-// ブログタグを取得する
+// FetchBlogTags はブログタグを取得する。
 func (s *BlogServiceImpl) FetchBlogTags() ([]string, error) {
 	tagsList, err := s.BlogRepository.FetchBlogTags()
 	if err != nil {
@@ -199,7 +199,7 @@ func (s *BlogServiceImpl) FetchBlogTags() ([]string, error) {
 	return result, nil
 }
 
-// 人気のあるブログを取得する
+// FetchBlogPopular は人気のあるブログを取得する。
 func (s *BlogServiceImpl) FetchBlogPopular(count int) ([]models.BlogData, error) {
 
 	// バリデーション

--- a/backend/services/blogs/blogs.go
+++ b/backend/services/blogs/blogs.go
@@ -9,11 +9,22 @@ import (
 )
 
 // FetchBlogs は全ブログデータを取得する。
+//
+// 戻り値:
+//   - []models.BlogData: 取得した全ブログデータの一覧
+//   - error: 取得に失敗した場合のエラー
 func (s *BlogServiceImpl) FetchBlogs() ([]models.BlogData, error) {
 	return s.BlogRepository.FetchBlogs()
 }
 
 // FetchBlogsByUserId は指定されたユーザーIDに一致するブログデータを取得する。
+//
+// 引数:
+//   - userId: 取得対象のユーザーID
+//
+// 戻り値:
+//   - []models.BlogData: 取得したブログデータの一覧
+//   - error: 取得に失敗した場合のエラー
 func (s *BlogServiceImpl) FetchBlogsByUserId(userId string) ([]models.BlogData, error) {
 	logger.InfoLog.Printf("FetchBlogsByUserId start...")
 
@@ -36,6 +47,13 @@ func (s *BlogServiceImpl) FetchBlogsByUserId(userId string) ([]models.BlogData, 
 }
 
 // FetchBlogById は指定されたIDに一致するブログデータを取得する。
+//
+// 引数:
+//   - id: 取得対象のブログID
+//
+// 戻り値:
+//   - *models.BlogData: 見つかったブログデータ
+//   - error: 取得に失敗した場合のエラー
 func (s *BlogServiceImpl) FetchBlogById(id string) (*models.BlogData, error) {
 	logger.InfoLog.Printf("FetchBlogById start...")
 
@@ -58,6 +76,18 @@ func (s *BlogServiceImpl) FetchBlogById(id string) (*models.BlogData, error) {
 }
 
 // CreateBlog はブログデータを作成する。
+//
+// 引数:
+//   - userId: 投稿者のユーザーID
+//   - title: ブログのタイトル
+//   - githubUrl: 関連する GitHub の URL
+//   - category: ブログのカテゴリ
+//   - description: ブログの本文・説明
+//   - tags: カンマ区切りのタグ文字列
+//
+// 戻り値:
+//   - *models.BlogData: 作成されたブログデータ
+//   - error: 作成に失敗した場合のエラー
 func (s *BlogServiceImpl) CreateBlog(userId, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	logger.InfoLog.Printf("CreateBlog start...")
 
@@ -100,6 +130,18 @@ func (s *BlogServiceImpl) CreateBlog(userId, title, githubUrl, category, descrip
 }
 
 // UpdateBlog は指定されたIDに一致するブログデータを更新する。
+//
+// 引数:
+//   - id: 更新対象のブログID
+//   - title: 更新後のタイトル
+//   - githubUrl: 更新後の GitHub の URL
+//   - category: 更新後のカテゴリ
+//   - description: 更新後の本文・説明
+//   - tags: 更新後のカンマ区切りのタグ文字列
+//
+// 戻り値:
+//   - *models.BlogData: 更新後のブログデータ
+//   - error: 更新に失敗した場合のエラー
 func (s *BlogServiceImpl) UpdateBlog(id, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	logger.InfoLog.Printf("UpdateBlog start...")
 
@@ -142,6 +184,12 @@ func (s *BlogServiceImpl) UpdateBlog(id, title, githubUrl, category, description
 }
 
 // DeleteBlog は指定されたIDに一致するブログデータを削除する。
+//
+// 引数:
+//   - id: 削除対象のブログID
+//
+// 戻り値:
+//   - error: 削除に失敗した場合のエラー
 func (s *BlogServiceImpl) DeleteBlog(id string) error {
 	logger.InfoLog.Printf("DeleteBlog start...")
 
@@ -164,11 +212,19 @@ func (s *BlogServiceImpl) DeleteBlog(id string) error {
 }
 
 // FetchBlogCategories はブログカテゴリを取得する。
+//
+// 戻り値:
+//   - []string: 取得したカテゴリ名の一覧
+//   - error: 取得に失敗した場合のエラー
 func (s *BlogServiceImpl) FetchBlogCategories() ([]string, error) {
 	return s.BlogRepository.FetchBlogCategories()
 }
 
 // FetchBlogTags はブログタグを取得する。
+//
+// 戻り値:
+//   - []string: 重複排除・ソート済みのタグ名一覧
+//   - error: 取得に失敗した場合のエラー
 func (s *BlogServiceImpl) FetchBlogTags() ([]string, error) {
 	tagsList, err := s.BlogRepository.FetchBlogTags()
 	if err != nil {
@@ -200,6 +256,13 @@ func (s *BlogServiceImpl) FetchBlogTags() ([]string, error) {
 }
 
 // FetchBlogPopular は人気のあるブログを取得する。
+//
+// 引数:
+//   - count: 取得する件数
+//
+// 戻り値:
+//   - []models.BlogData: 取得した人気ブログデータの一覧
+//   - error: 取得に失敗した場合のエラー
 func (s *BlogServiceImpl) FetchBlogPopular(count int) ([]models.BlogData, error) {
 
 	// バリデーション

--- a/backend/services/blogs/blogs_impl.go
+++ b/backend/services/blogs/blogs_impl.go
@@ -8,24 +8,87 @@ import (
 // BlogService はブログに関する処理を提供するサービスインターフェース。
 type BlogService interface {
 	// FetchBlogs は全ブログデータを取得する。
+	//
+	// 戻り値:
+	//   - []models.BlogData: 取得した全ブログデータの一覧
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogs() ([]models.BlogData, error)
 	// FetchBlogsByUserId は指定されたユーザーIDに一致するブログデータを取得する。
+	//
+	// 引数:
+	//   - userId: 取得対象のユーザーID
+	//
+	// 戻り値:
+	//   - []models.BlogData: 取得したブログデータの一覧
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogsByUserId(userId string) ([]models.BlogData, error)
 	// FetchBlogById は指定されたIDに一致するブログデータを取得する。
+	//
+	// 引数:
+	//   - id: 取得対象のブログID
+	//
+	// 戻り値:
+	//   - *models.BlogData: 見つかったブログデータ
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogById(id string) (*models.BlogData, error)
 
 	// CreateBlog はブログデータを作成する。
+	//
+	// 引数:
+	//   - userId: 投稿者のユーザーID
+	//   - title: ブログのタイトル
+	//   - githubUrl: 関連する GitHub の URL
+	//   - category: ブログのカテゴリ
+	//   - description: ブログの本文・説明
+	//   - tags: カンマ区切りのタグ文字列
+	//
+	// 戻り値:
+	//   - *models.BlogData: 作成されたブログデータ
+	//   - error: 作成に失敗した場合のエラー
 	CreateBlog(userId, title, githubUrl, category, description, tags string) (*models.BlogData, error)
 	// UpdateBlog は指定されたIDに一致するブログデータを更新する。
+	//
+	// 引数:
+	//   - id: 更新対象のブログID
+	//   - title: 更新後のタイトル
+	//   - githubUrl: 更新後の GitHub の URL
+	//   - category: 更新後のカテゴリ
+	//   - description: 更新後の本文・説明
+	//   - tags: 更新後のカンマ区切りのタグ文字列
+	//
+	// 戻り値:
+	//   - *models.BlogData: 更新後のブログデータ
+	//   - error: 更新に失敗した場合のエラー
 	UpdateBlog(id, title, githubUrl, category, description, tags string) (*models.BlogData, error)
 	// DeleteBlog は指定されたIDに一致するブログデータを削除する。
+	//
+	// 引数:
+	//   - id: 削除対象のブログID
+	//
+	// 戻り値:
+	//   - error: 削除に失敗した場合のエラー
 	DeleteBlog(id string) error
 
 	// FetchBlogCategories はブログカテゴリを取得する。
+	//
+	// 戻り値:
+	//   - []string: 取得したカテゴリ名の一覧
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogCategories() ([]string, error)
 	// FetchBlogTags はブログタグを取得する。
+	//
+	// 戻り値:
+	//   - []string: 重複排除・ソート済みのタグ名一覧
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogTags() ([]string, error)
 	// FetchBlogPopular は人気のあるブログを取得する。
+	//
+	// 引数:
+	//   - count: 取得する件数
+	//
+	// 戻り値:
+	//   - []models.BlogData: 取得した人気ブログデータの一覧
+	//   - error: 取得に失敗した場合のエラー
 	FetchBlogPopular(count int) ([]models.BlogData, error)
 }
 
@@ -35,6 +98,12 @@ type BlogServiceImpl struct {
 }
 
 // NewBlogService は BlogService インターフェースを実装した BlogServiceImpl を生成する。
+//
+// 引数:
+//   - blogRepository: ブログデータへのアクセスを担うリポジトリ
+//
+// 戻り値:
+//   - BlogService: 生成されたブログサービス
 func NewBlogService(
 	blogRepository repositories_blogs.BlogRepository,
 ) BlogService {

--- a/backend/services/blogs/blogs_impl.go
+++ b/backend/services/blogs/blogs_impl.go
@@ -5,26 +5,36 @@ import (
 	repositories_blogs "backend/repositories/blogs"
 )
 
-// BlogServiceインターフェース
+// BlogService はブログに関する処理を提供するサービスインターフェース。
 type BlogService interface {
+	// FetchBlogs は全ブログデータを取得する。
 	FetchBlogs() ([]models.BlogData, error)
+	// FetchBlogsByUserId は指定されたユーザーIDに一致するブログデータを取得する。
 	FetchBlogsByUserId(userId string) ([]models.BlogData, error)
+	// FetchBlogById は指定されたIDに一致するブログデータを取得する。
 	FetchBlogById(id string) (*models.BlogData, error)
 
+	// CreateBlog はブログデータを作成する。
 	CreateBlog(userId, title, githubUrl, category, description, tags string) (*models.BlogData, error)
+	// UpdateBlog は指定されたIDに一致するブログデータを更新する。
 	UpdateBlog(id, title, githubUrl, category, description, tags string) (*models.BlogData, error)
+	// DeleteBlog は指定されたIDに一致するブログデータを削除する。
 	DeleteBlog(id string) error
 
+	// FetchBlogCategories はブログカテゴリを取得する。
 	FetchBlogCategories() ([]string, error)
+	// FetchBlogTags はブログタグを取得する。
 	FetchBlogTags() ([]string, error)
+	// FetchBlogPopular は人気のあるブログを取得する。
 	FetchBlogPopular(count int) ([]models.BlogData, error)
 }
 
+// BlogServiceImpl は BlogService の実装。
 type BlogServiceImpl struct {
 	BlogRepository repositories_blogs.BlogRepository
 }
 
-// BlogServiceインターフェースを実装したBlogServiceImplのポインタを返す
+// NewBlogService は BlogService インターフェースを実装した BlogServiceImpl を生成する。
 func NewBlogService(
 	blogRepository repositories_blogs.BlogRepository,
 ) BlogService {

--- a/backend/services/blogs/blogs_mock.go
+++ b/backend/services/blogs/blogs_mock.go
@@ -12,6 +12,10 @@ type MockBlogService struct {
 }
 
 // FetchBlogs は BlogService.FetchBlogs のテスト用モック。
+//
+// 戻り値:
+//   - []models.BlogData: モックの戻り値設定に従う全ブログデータの一覧
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogService) FetchBlogs() ([]models.BlogData, error) {
 	args := m.Called()
 	if args.Get(0) != nil {
@@ -21,6 +25,13 @@ func (m *MockBlogService) FetchBlogs() ([]models.BlogData, error) {
 }
 
 // FetchBlogsByUserId は BlogService.FetchBlogsByUserId のテスト用モック。
+//
+// 引数:
+//   - userId: 取得対象のユーザーID
+//
+// 戻り値:
+//   - []models.BlogData: モックの戻り値設定に従うブログデータの一覧
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogService) FetchBlogsByUserId(userId string) ([]models.BlogData, error) {
 	args := m.Called(userId)
 	if args.Get(0) == nil {
@@ -30,6 +41,13 @@ func (m *MockBlogService) FetchBlogsByUserId(userId string) ([]models.BlogData, 
 }
 
 // FetchBlogById は BlogService.FetchBlogById のテスト用モック。
+//
+// 引数:
+//   - id: 取得対象のブログID
+//
+// 戻り値:
+//   - *models.BlogData: モックの戻り値設定に従うブログデータ
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogService) FetchBlogById(id string) (*models.BlogData, error) {
 	args := m.Called(id)
 	if args.Get(0) == nil {
@@ -39,6 +57,18 @@ func (m *MockBlogService) FetchBlogById(id string) (*models.BlogData, error) {
 }
 
 // CreateBlog は BlogService.CreateBlog のテスト用モック。
+//
+// 引数:
+//   - userId: 投稿者のユーザーID
+//   - title: ブログのタイトル
+//   - githubUrl: 関連する GitHub の URL
+//   - category: ブログのカテゴリ
+//   - description: ブログの本文・説明
+//   - tags: カンマ区切りのタグ文字列
+//
+// 戻り値:
+//   - *models.BlogData: モックの戻り値設定に従う作成済みブログデータ
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogService) CreateBlog(userId, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	args := m.Called(userId, title, githubUrl, category, description, tags)
 	if args.Get(0) == nil {
@@ -48,6 +78,18 @@ func (m *MockBlogService) CreateBlog(userId, title, githubUrl, category, descrip
 }
 
 // UpdateBlog は BlogService.UpdateBlog のテスト用モック。
+//
+// 引数:
+//   - id: 更新対象のブログID
+//   - title: 更新後のタイトル
+//   - githubUrl: 更新後の GitHub の URL
+//   - category: 更新後のカテゴリ
+//   - description: 更新後の本文・説明
+//   - tags: 更新後のカンマ区切りのタグ文字列
+//
+// 戻り値:
+//   - *models.BlogData: モックの戻り値設定に従う更新後ブログデータ
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogService) UpdateBlog(id, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	args := m.Called(id, title, githubUrl, category, description, tags)
 	if args.Get(0) == nil {
@@ -57,12 +99,22 @@ func (m *MockBlogService) UpdateBlog(id, title, githubUrl, category, description
 }
 
 // DeleteBlog は BlogService.DeleteBlog のテスト用モック。
+//
+// 引数:
+//   - id: 削除対象のブログID
+//
+// 戻り値:
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogService) DeleteBlog(id string) error {
 	args := m.Called(id)
 	return args.Error(0)
 }
 
 // FetchBlogCategories は BlogService.FetchBlogCategories のテスト用モック。
+//
+// 戻り値:
+//   - []string: モックの戻り値設定に従うカテゴリ名の一覧
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogService) FetchBlogCategories() ([]string, error) {
 	args := m.Called()
 	if args.Get(0) != nil {
@@ -72,6 +124,10 @@ func (m *MockBlogService) FetchBlogCategories() ([]string, error) {
 }
 
 // FetchBlogTags は BlogService.FetchBlogTags のテスト用モック。
+//
+// 戻り値:
+//   - []string: モックの戻り値設定に従うタグ名の一覧
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogService) FetchBlogTags() ([]string, error) {
 	args := m.Called()
 	if args.Get(0) != nil {
@@ -81,6 +137,13 @@ func (m *MockBlogService) FetchBlogTags() ([]string, error) {
 }
 
 // FetchBlogPopular は BlogService.FetchBlogPopular のテスト用モック。
+//
+// 引数:
+//   - count: 取得する件数
+//
+// 戻り値:
+//   - []models.BlogData: モックの戻り値設定に従う人気ブログデータの一覧
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockBlogService) FetchBlogPopular(count int) ([]models.BlogData, error) {
 	args := m.Called(count)
 	if args.Get(0) != nil {

--- a/backend/services/blogs/blogs_mock.go
+++ b/backend/services/blogs/blogs_mock.go
@@ -6,10 +6,12 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// MockBlogService は BlogService のテスト用モック。
 type MockBlogService struct {
 	mock.Mock
 }
 
+// FetchBlogs は BlogService.FetchBlogs のテスト用モック。
 func (m *MockBlogService) FetchBlogs() ([]models.BlogData, error) {
 	args := m.Called()
 	if args.Get(0) != nil {
@@ -18,6 +20,7 @@ func (m *MockBlogService) FetchBlogs() ([]models.BlogData, error) {
 	return nil, args.Error(1)
 }
 
+// FetchBlogsByUserId は BlogService.FetchBlogsByUserId のテスト用モック。
 func (m *MockBlogService) FetchBlogsByUserId(userId string) ([]models.BlogData, error) {
 	args := m.Called(userId)
 	if args.Get(0) == nil {
@@ -26,6 +29,7 @@ func (m *MockBlogService) FetchBlogsByUserId(userId string) ([]models.BlogData, 
 	return args.Get(0).([]models.BlogData), args.Error(1)
 }
 
+// FetchBlogById は BlogService.FetchBlogById のテスト用モック。
 func (m *MockBlogService) FetchBlogById(id string) (*models.BlogData, error) {
 	args := m.Called(id)
 	if args.Get(0) == nil {
@@ -34,6 +38,7 @@ func (m *MockBlogService) FetchBlogById(id string) (*models.BlogData, error) {
 	return args.Get(0).(*models.BlogData), args.Error(1)
 }
 
+// CreateBlog は BlogService.CreateBlog のテスト用モック。
 func (m *MockBlogService) CreateBlog(userId, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	args := m.Called(userId, title, githubUrl, category, description, tags)
 	if args.Get(0) == nil {
@@ -42,6 +47,7 @@ func (m *MockBlogService) CreateBlog(userId, title, githubUrl, category, descrip
 	return args.Get(0).(*models.BlogData), args.Error(1)
 }
 
+// UpdateBlog は BlogService.UpdateBlog のテスト用モック。
 func (m *MockBlogService) UpdateBlog(id, title, githubUrl, category, description, tags string) (*models.BlogData, error) {
 	args := m.Called(id, title, githubUrl, category, description, tags)
 	if args.Get(0) == nil {
@@ -50,11 +56,13 @@ func (m *MockBlogService) UpdateBlog(id, title, githubUrl, category, description
 	return args.Get(0).(*models.BlogData), args.Error(1)
 }
 
+// DeleteBlog は BlogService.DeleteBlog のテスト用モック。
 func (m *MockBlogService) DeleteBlog(id string) error {
 	args := m.Called(id)
 	return args.Error(0)
 }
 
+// FetchBlogCategories は BlogService.FetchBlogCategories のテスト用モック。
 func (m *MockBlogService) FetchBlogCategories() ([]string, error) {
 	args := m.Called()
 	if args.Get(0) != nil {
@@ -63,6 +71,7 @@ func (m *MockBlogService) FetchBlogCategories() ([]string, error) {
 	return nil, args.Error(1)
 }
 
+// FetchBlogTags は BlogService.FetchBlogTags のテスト用モック。
 func (m *MockBlogService) FetchBlogTags() ([]string, error) {
 	args := m.Called()
 	if args.Get(0) != nil {
@@ -71,6 +80,7 @@ func (m *MockBlogService) FetchBlogTags() ([]string, error) {
 	return nil, args.Error(1)
 }
 
+// FetchBlogPopular は BlogService.FetchBlogPopular のテスト用モック。
 func (m *MockBlogService) FetchBlogPopular(count int) ([]models.BlogData, error) {
 	args := m.Called(count)
 	if args.Get(0) != nil {

--- a/backend/services/blogs/blogs_testing_setup.go
+++ b/backend/services/blogs/blogs_testing_setup.go
@@ -8,6 +8,9 @@ import (
 )
 
 // SetupTest はテストの前に環境変数を読み込み、ログ設定を初期化する。
+//
+// 引数:
+//   - t: 呼び出し元のテスト。環境変数ファイル未検出時のログ出力に使用する
 func SetupTest(t *testing.T) {
 	// 環境変数の読み込み
 	err := godotenv.Load("../../../.env.test")

--- a/backend/services/blogs/blogs_testing_setup.go
+++ b/backend/services/blogs/blogs_testing_setup.go
@@ -7,7 +7,7 @@ import (
 	"github.com/joho/godotenv"
 )
 
-// Setup はテストの前に環境変数を読み込み、ログ設定を初期化します
+// SetupTest はテストの前に環境変数を読み込み、ログ設定を初期化する。
 func SetupTest(t *testing.T) {
 	// 環境変数の読み込み
 	err := godotenv.Load("../../../.env.test")

--- a/backend/supabase/client.go
+++ b/backend/supabase/client.go
@@ -23,6 +23,9 @@ var (
 // 接続URLを環境変数から取得し、コネクションプールを設定する。
 // コネクションの最大数やアイドルタイム、シンプルプロトコルの使用を設定する。
 // 成功時にはnilを返し、接続に失敗した場合はエラーメッセージを返す。
+//
+// 戻り値:
+//   - error: 初期化に成功した場合は nil、接続に失敗した場合のエラー
 func InitSupabase() error {
 	logger.InfoLog.Println("Initializing Supabase client...")
 	supabaseURL := os.Getenv("SUPABASE_URL") + "?sslmode=require"
@@ -70,6 +73,9 @@ func ClosePool() {
 // TestQuery は Supabase に対してシンプルなクエリを実行し、接続が正しく動作しているかを確認する。
 // クエリ結果として "1" を取得し、それをログに出力する。
 // クエリに失敗した場合、エラーを返す。
+//
+// 戻り値:
+//   - error: クエリ実行に成功した場合は nil、失敗した場合のエラー
 func TestQuery() error {
 	logger.InfoLog.Println("Testing query...")
 	query := `SELECT 1`

--- a/backend/supabase/client.go
+++ b/backend/supabase/client.go
@@ -13,14 +13,14 @@ import (
 )
 
 var (
-	// Supabaseとのやり取りに使用するグローバルなコンテキスト。
+	// Ctx は Supabase とのやり取りに使用するグローバルなコンテキスト。
 	Ctx = context.Background()
-	// Supabaseとの接続プールです。クエリ実行時に使用。
+	// Pool は Supabase との接続プール。クエリ実行時に使用する。
 	Pool *pgxpool.Pool
 )
 
-// Supabaseの接続を初期化
-// Supabaseの接続URLを環境変数から取得し、コネクションプールを設定する。
+// InitSupabase は Supabase の接続を初期化する。
+// 接続URLを環境変数から取得し、コネクションプールを設定する。
 // コネクションの最大数やアイドルタイム、シンプルプロトコルの使用を設定する。
 // 成功時にはnilを返し、接続に失敗した場合はエラーメッセージを返す。
 func InitSupabase() error {
@@ -58,7 +58,7 @@ func InitSupabase() error {
 	return nil
 }
 
-// Supabaseのコネクションプールをクローズ。
+// ClosePool は Supabase のコネクションプールをクローズする。
 // この関数はアプリケーションのシャットダウン時に呼び出されることを想定する。
 func ClosePool() {
 	if Pool != nil {
@@ -67,9 +67,9 @@ func ClosePool() {
 	}
 }
 
-// Supabaseに対してシンプルなクエリを実行し、接続が正しく動作しているかを確認する。
+// TestQuery は Supabase に対してシンプルなクエリを実行し、接続が正しく動作しているかを確認する。
 // クエリ結果として "1" を取得し、それをログに出力する。
-// クエリに失敗した場合、エラーを返する。
+// クエリに失敗した場合、エラーを返す。
 func TestQuery() error {
 	logger.InfoLog.Println("Testing query...")
 	query := `SELECT 1`

--- a/backend/utils/cookie/cookie_common_di.go
+++ b/backend/utils/cookie/cookie_common_di.go
@@ -12,6 +12,14 @@ import (
 )
 
 // GetAuthCookie - 認証用のCookieを取得
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenName: 取得対象のCookie名
+//
+// 戻り値:
+//   - *http.Cookie: 取得したCookie
+//   - error: Cookieが存在しない等、取得に失敗した場合のエラー
 func (u *CookieUtilsImpl) GetAuthCookie(c echo.Context, tokenName string) (*http.Cookie, error) {
 	cookie, err := c.Cookie(tokenName)
 	if err != nil {
@@ -21,6 +29,14 @@ func (u *CookieUtilsImpl) GetAuthCookie(c echo.Context, tokenName string) (*http
 }
 
 // GetAuthCookieValue - 認証用のCookieの値を取得
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenName: 取得対象のCookie名
+//
+// 戻り値:
+//   - string: 取得したCookieの値
+//   - error: Cookieが存在しない等、取得に失敗した場合のエラー
 func (u *CookieUtilsImpl) GetAuthCookieValue(c echo.Context, tokenName string) (string, error) {
 	cookie, err := u.GetAuthCookie(c, tokenName)
 	if err != nil {
@@ -30,17 +46,35 @@ func (u *CookieUtilsImpl) GetAuthCookieValue(c echo.Context, tokenName string) (
 }
 
 // GetAuthCookieExpirationTime - 認証用のCookieの有効期限を取得
+//
+// 戻り値:
+//   - time.Time: 現在時刻から1時間後の有効期限
 func (u *CookieUtilsImpl) GetAuthCookieExpirationTime() time.Time {
 	return time.Now().Add(1 * time.Hour)
 }
 
 // ExistsAuthCookie - 認証用のCookieが存在するか確認
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenName: 確認対象のCookie名
+//
+// 戻り値:
+//   - bool: Cookieが存在する場合はtrue、存在しない場合はfalse
 func (u *CookieUtilsImpl) ExistsAuthCookie(c echo.Context, tokenName string) bool {
 	_, err := u.GetAuthCookie(c, tokenName)
 	return err == nil
 }
 
 // VerifyToken - JWTトークンを検証
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenString: 検証対象のJWTトークン文字列
+//
+// 戻り値:
+//   - *models.Claims: 検証に成功したトークンのクレーム情報
+//   - error: トークンが無効または有効期限切れの場合のエラー
 func (u *CookieUtilsImpl) VerifyToken(c echo.Context, tokenString string) (*models.Claims, error) {
 	claims := &models.Claims{}
 	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {

--- a/backend/utils/cookie/cookie_impl.go
+++ b/backend/utils/cookie/cookie_impl.go
@@ -11,22 +11,127 @@ import (
 // CookieUtils インターフェース
 type CookieUtils interface {
 	// Token用
+
+	// GetAuthCookie は認証用のCookieを取得する。
+	//
+	// 引数:
+	//   - c: Echoのリクエストコンテキスト
+	//   - tokenName: 取得対象のCookie名
+	//
+	// 戻り値:
+	//   - *http.Cookie: 取得したCookie
+	//   - error: Cookieが存在しない等、取得に失敗した場合のエラー
 	GetAuthCookie(c echo.Context, tokenName string) (*http.Cookie, error)
+
+	// GetAuthCookieValue は認証用のCookieの値を取得する。
+	//
+	// 引数:
+	//   - c: Echoのリクエストコンテキスト
+	//   - tokenName: 取得対象のCookie名
+	//
+	// 戻り値:
+	//   - string: 取得したCookieの値
+	//   - error: Cookieが存在しない等、取得に失敗した場合のエラー
 	GetAuthCookieValue(c echo.Context, tokenName string) (string, error)
+
+	// GetAuthCookieExpirationTime は認証用のCookieの有効期限を取得する。
+	//
+	// 戻り値:
+	//   - time.Time: 現在時刻から1時間後の有効期限
 	GetAuthCookieExpirationTime() time.Time
+
+	// ExistsAuthCookie は認証用のCookieが存在するか確認する。
+	//
+	// 引数:
+	//   - c: Echoのリクエストコンテキスト
+	//   - tokenName: 確認対象のCookie名
+	//
+	// 戻り値:
+	//   - bool: Cookieが存在する場合はtrue、存在しない場合はfalse
 	ExistsAuthCookie(c echo.Context, tokenName string) bool
+
+	// VerifyToken はJWTトークンを検証する。
+	//
+	// 引数:
+	//   - c: Echoのリクエストコンテキスト
+	//   - tokenString: 検証対象のJWTトークン文字列
+	//
+	// 戻り値:
+	//   - *models.Claims: 検証に成功したトークンのクレーム情報
+	//   - error: トークンが無効または有効期限切れの場合のエラー
 	VerifyToken(c echo.Context, tokenString string) (*models.Claims, error)
 
 	// 認証Token用
+
+	// CreateToken はJWTトークンを作成する。
+	//
+	// 引数:
+	//   - user: トークンに埋め込むユーザー情報
+	//
+	// 戻り値:
+	//   - string: 生成したJWTトークン文字列
+	//   - error: トークンの署名に失敗した場合のエラー
 	CreateToken(user *models.BlogUsersData) (string, error)
+
+	// AddAuthCookie は認証用のCookieを追加する。
+	//
+	// 引数:
+	//   - c: Echoのリクエストコンテキスト
+	//   - tokenString: Cookieに保存するJWTトークン文字列
+	//   - expirationTime: Cookieの有効期限
 	AddAuthCookie(c echo.Context, tokenString string, expirationTime time.Time)
+
+	// UpdateAuthCookie は認証用のCookieを更新する。
+	//
+	// 引数:
+	//   - c: Echoのリクエストコンテキスト
+	//   - tokenString: Cookieに保存する更新後のJWTトークン文字列
+	//   - expirationTime: Cookieの有効期限
 	UpdateAuthCookie(c echo.Context, tokenString string, expirationTime time.Time)
+
+	// DelAuthCookie は認証用のCookieを削除する。
+	//
+	// 引数:
+	//   - c: Echoのリクエストコンテキスト
 	DelAuthCookie(c echo.Context)
+
+	// GetUserIdFromToken はJWTトークンを解析してユーザーIDを取得する。
+	//
+	// 引数:
+	//   - c: Echoのリクエストコンテキスト
+	//   - tokenString: 解析対象のJWTトークン文字列
+	//
+	// 戻り値:
+	//   - string: トークンから取得したユーザーID
+	//   - error: トークンが無効または有効期限切れの場合のエラー
 	GetUserIdFromToken(c echo.Context, tokenString string) (string, error)
 
 	// VisitId用
+
+	// CreateVisitIdToken はvisitId用JWTトークンを作成する。
+	//
+	// 戻り値:
+	//   - string: 生成したvisitId用JWTトークン文字列
+	//   - error: トークンの署名に失敗した場合のエラー
 	CreateVisitIdToken() (string, error)
+
+	// AddVisitIdCoookie は訪問者ID用のCookieを追加する。
+	//
+	// 引数:
+	//   - c: Echoのリクエストコンテキスト
+	//   - tokenString: Cookieに保存するvisitId用JWTトークン文字列
+	//   - expirationTime: Cookieの有効期限
 	AddVisitIdCoookie(c echo.Context, tokenString string, expirationTime time.Time)
+
+	// GetVisitIdFromToken は訪問者IDを取得する。
+	//
+	// 引数:
+	//   - c: Echoのリクエストコンテキスト
+	//   - tokenString: 解析対象のvisitId用JWTトークン文字列
+	//
+	// 戻り値:
+	//   - string: トークンから取得した訪問者ID
+	//   - error: トークンが無効または有効期限切れの場合のエラー
 	GetVisitIdFromToken(c echo.Context, tokenString string) (string, error)
 }
 
@@ -34,6 +139,9 @@ type CookieUtils interface {
 type CookieUtilsImpl struct{}
 
 // NewCookieUtils は CookieUtils を生成する。
+//
+// 戻り値:
+//   - CookieUtils: 生成したCookieUtilsの実装
 func NewCookieUtils() CookieUtils {
 	return &CookieUtilsImpl{}
 }

--- a/backend/utils/cookie/cookie_impl.go
+++ b/backend/utils/cookie/cookie_impl.go
@@ -30,8 +30,10 @@ type CookieUtils interface {
 	GetVisitIdFromToken(c echo.Context, tokenString string) (string, error)
 }
 
+// CookieUtilsImpl は CookieUtils の実装。
 type CookieUtilsImpl struct{}
 
+// NewCookieUtils は CookieUtils を生成する。
 func NewCookieUtils() CookieUtils {
 	return &CookieUtilsImpl{}
 }

--- a/backend/utils/cookie/cookie_mock.go
+++ b/backend/utils/cookie/cookie_mock.go
@@ -19,6 +19,14 @@ type MockCookieUtils struct {
 // ----------------------------------------------------------------------------------------------------------
 
 // GetAuthCookie は GetAuthCookie のテスト用モック。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenName: 取得対象のCookie名
+//
+// 戻り値:
+//   - *http.Cookie: モックの戻り値設定に従うCookie
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockCookieUtils) GetAuthCookie(c echo.Context, tokenName string) (*http.Cookie, error) {
 	args := m.Called(c, tokenName)
 
@@ -31,24 +39,50 @@ func (m *MockCookieUtils) GetAuthCookie(c echo.Context, tokenName string) (*http
 }
 
 // GetAuthCookieValue は GetAuthCookieValue のテスト用モック。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenName: 取得対象のCookie名
+//
+// 戻り値:
+//   - string: モックの戻り値設定に従うCookieの値
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockCookieUtils) GetAuthCookieValue(c echo.Context, tokenName string) (string, error) {
 	args := m.Called(c, tokenName)
 	return args.String(0), args.Error(1)
 }
 
 // GetAuthCookieExpirationTime は GetAuthCookieExpirationTime のテスト用モック。
+//
+// 戻り値:
+//   - time.Time: モックの戻り値設定に従う有効期限
 func (m *MockCookieUtils) GetAuthCookieExpirationTime() time.Time {
 	args := m.Called()
 	return args.Get(0).(time.Time)
 }
 
 // ExistsAuthCookie は ExistsAuthCookie のテスト用モック。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenName: 確認対象のCookie名
+//
+// 戻り値:
+//   - bool: モックの戻り値設定に従う存在有無
 func (m *MockCookieUtils) ExistsAuthCookie(c echo.Context, tokenName string) bool {
 	args := m.Called(c, tokenName)
 	return args.Bool(0)
 }
 
 // VerifyToken は VerifyToken のテスト用モック。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenString: 検証対象のJWTトークン文字列
+//
+// 戻り値:
+//   - *models.Claims: モックの戻り値設定に従うクレーム情報
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockCookieUtils) VerifyToken(c echo.Context, tokenString string) (*models.Claims, error) {
 	args := m.Called(c, tokenString)
 	return args.Get(0).(*models.Claims), args.Error(1)
@@ -59,27 +93,55 @@ func (m *MockCookieUtils) VerifyToken(c echo.Context, tokenString string) (*mode
 // ----------------------------------------------------------------------------------------------------------
 
 // CreateToken は CreateToken のテスト用モック。
+//
+// 引数:
+//   - user: トークンに埋め込むユーザー情報
+//
+// 戻り値:
+//   - string: モックの戻り値設定に従うJWTトークン文字列
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockCookieUtils) CreateToken(user *models.BlogUsersData) (string, error) {
 	args := m.Called(user)
 	return args.String(0), args.Error(1)
 }
 
 // AddAuthCookie は AddAuthCookie のテスト用モック。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenString: Cookieに保存するJWTトークン文字列
+//   - expirationTime: Cookieの有効期限
 func (m *MockCookieUtils) AddAuthCookie(c echo.Context, tokenString string, expirationTime time.Time) {
 	m.Called(c, tokenString, expirationTime)
 }
 
 // UpdateAuthCookie は UpdateAuthCookie のテスト用モック。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenString: Cookieに保存する更新後のJWTトークン文字列
+//   - expirationTime: Cookieの有効期限
 func (m *MockCookieUtils) UpdateAuthCookie(c echo.Context, tokenString string, expirationTime time.Time) {
 	m.Called(c, tokenString, expirationTime)
 }
 
 // DelAuthCookie は DelAuthCookie のテスト用モック。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
 func (m *MockCookieUtils) DelAuthCookie(c echo.Context) {
 	m.Called(c)
 }
 
 // GetUserIdFromToken は GetUserIdFromToken のテスト用モック。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenString: 解析対象のJWTトークン文字列
+//
+// 戻り値:
+//   - string: モックの戻り値設定に従うユーザーID
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockCookieUtils) GetUserIdFromToken(c echo.Context, tokenString string) (string, error) {
 	args := m.Called(c, tokenString)
 	return args.String(0), args.Error(1)
@@ -90,17 +152,34 @@ func (m *MockCookieUtils) GetUserIdFromToken(c echo.Context, tokenString string)
 // ----------------------------------------------------------------------------------------------------------
 
 // CreateVisitIdToken は CreateVisitIdToken のテスト用モック。
+//
+// 戻り値:
+//   - string: モックの戻り値設定に従うvisitId用JWTトークン文字列
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockCookieUtils) CreateVisitIdToken() (string, error) {
 	args := m.Called()
 	return args.String(0), args.Error(1)
 }
 
 // AddVisitIdCoookie は AddVisitIdCoookie のテスト用モック。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenString: Cookieに保存するvisitId用JWTトークン文字列
+//   - expirationTime: Cookieの有効期限
 func (m *MockCookieUtils) AddVisitIdCoookie(c echo.Context, tokenString string, expirationTime time.Time) {
 	m.Called(c, tokenString, expirationTime)
 }
 
 // GetVisitIdFromToken は GetVisitIdFromToken のテスト用モック。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenString: 解析対象のvisitId用JWTトークン文字列
+//
+// 戻り値:
+//   - string: モックの戻り値設定に従う訪問者ID
+//   - error: モックの戻り値設定に従うエラー
 func (m *MockCookieUtils) GetVisitIdFromToken(c echo.Context, tokenString string) (string, error) {
 	args := m.Called(c, tokenString)
 	return args.String(0), args.Error(1)

--- a/backend/utils/cookie/cookie_mock.go
+++ b/backend/utils/cookie/cookie_mock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// MockCookieUtils は CookieUtils のテスト用モック。
 type MockCookieUtils struct {
 	mock.Mock
 }
@@ -17,6 +18,7 @@ type MockCookieUtils struct {
 // Common用
 // ----------------------------------------------------------------------------------------------------------
 
+// GetAuthCookie は GetAuthCookie のテスト用モック。
 func (m *MockCookieUtils) GetAuthCookie(c echo.Context, tokenName string) (*http.Cookie, error) {
 	args := m.Called(c, tokenName)
 
@@ -28,21 +30,25 @@ func (m *MockCookieUtils) GetAuthCookie(c echo.Context, tokenName string) (*http
 	return nil, args.Error(1)
 }
 
+// GetAuthCookieValue は GetAuthCookieValue のテスト用モック。
 func (m *MockCookieUtils) GetAuthCookieValue(c echo.Context, tokenName string) (string, error) {
 	args := m.Called(c, tokenName)
 	return args.String(0), args.Error(1)
 }
 
+// GetAuthCookieExpirationTime は GetAuthCookieExpirationTime のテスト用モック。
 func (m *MockCookieUtils) GetAuthCookieExpirationTime() time.Time {
 	args := m.Called()
 	return args.Get(0).(time.Time)
 }
 
+// ExistsAuthCookie は ExistsAuthCookie のテスト用モック。
 func (m *MockCookieUtils) ExistsAuthCookie(c echo.Context, tokenName string) bool {
 	args := m.Called(c, tokenName)
 	return args.Bool(0)
 }
 
+// VerifyToken は VerifyToken のテスト用モック。
 func (m *MockCookieUtils) VerifyToken(c echo.Context, tokenString string) (*models.Claims, error) {
 	args := m.Called(c, tokenString)
 	return args.Get(0).(*models.Claims), args.Error(1)
@@ -52,23 +58,28 @@ func (m *MockCookieUtils) VerifyToken(c echo.Context, tokenString string) (*mode
 // 認証Token用
 // ----------------------------------------------------------------------------------------------------------
 
+// CreateToken は CreateToken のテスト用モック。
 func (m *MockCookieUtils) CreateToken(user *models.BlogUsersData) (string, error) {
 	args := m.Called(user)
 	return args.String(0), args.Error(1)
 }
 
+// AddAuthCookie は AddAuthCookie のテスト用モック。
 func (m *MockCookieUtils) AddAuthCookie(c echo.Context, tokenString string, expirationTime time.Time) {
 	m.Called(c, tokenString, expirationTime)
 }
 
+// UpdateAuthCookie は UpdateAuthCookie のテスト用モック。
 func (m *MockCookieUtils) UpdateAuthCookie(c echo.Context, tokenString string, expirationTime time.Time) {
 	m.Called(c, tokenString, expirationTime)
 }
 
+// DelAuthCookie は DelAuthCookie のテスト用モック。
 func (m *MockCookieUtils) DelAuthCookie(c echo.Context) {
 	m.Called(c)
 }
 
+// GetUserIdFromToken は GetUserIdFromToken のテスト用モック。
 func (m *MockCookieUtils) GetUserIdFromToken(c echo.Context, tokenString string) (string, error) {
 	args := m.Called(c, tokenString)
 	return args.String(0), args.Error(1)
@@ -78,15 +89,18 @@ func (m *MockCookieUtils) GetUserIdFromToken(c echo.Context, tokenString string)
 // VisitId用
 // ----------------------------------------------------------------------------------------------------------
 
+// CreateVisitIdToken は CreateVisitIdToken のテスト用モック。
 func (m *MockCookieUtils) CreateVisitIdToken() (string, error) {
 	args := m.Called()
 	return args.String(0), args.Error(1)
 }
 
+// AddVisitIdCoookie は AddVisitIdCoookie のテスト用モック。
 func (m *MockCookieUtils) AddVisitIdCoookie(c echo.Context, tokenString string, expirationTime time.Time) {
 	m.Called(c, tokenString, expirationTime)
 }
 
+// GetVisitIdFromToken は GetVisitIdFromToken のテスト用モック。
 func (m *MockCookieUtils) GetVisitIdFromToken(c echo.Context, tokenString string) (string, error) {
 	args := m.Called(c, tokenString)
 	return args.String(0), args.Error(1)

--- a/backend/utils/cookie/cookie_token_di.go
+++ b/backend/utils/cookie/cookie_token_di.go
@@ -12,6 +12,13 @@ import (
 )
 
 // CreateToken - JWTトークンを作成
+//
+// 引数:
+//   - user: トークンに埋め込むユーザー情報
+//
+// 戻り値:
+//   - string: 生成したJWTトークン文字列
+//   - error: トークンの署名に失敗した場合のエラー
 func (u *CookieUtilsImpl) CreateToken(user *models.BlogUsersData) (string, error) {
 	// トークンの有効期限を1時間に設定
 	expirationTime := u.GetAuthCookieExpirationTime()
@@ -39,6 +46,11 @@ func (u *CookieUtilsImpl) CreateToken(user *models.BlogUsersData) (string, error
 }
 
 // AddAuthCookie - 認証用のCookieを追加
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenString: Cookieに保存するJWTトークン文字列
+//   - expirationTime: Cookieの有効期限
 func (u *CookieUtilsImpl) AddAuthCookie(c echo.Context, tokenString string, expirationTime time.Time) {
 	cookie := new(http.Cookie)
 	cookie.Name = "token"
@@ -57,6 +69,11 @@ func (u *CookieUtilsImpl) AddAuthCookie(c echo.Context, tokenString string, expi
 }
 
 // UpdateAuthCookie - 認証用のCookieを更新
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenString: Cookieに保存する更新後のJWTトークン文字列
+//   - expirationTime: Cookieの有効期限
 func (u *CookieUtilsImpl) UpdateAuthCookie(c echo.Context, tokenString string, expirationTime time.Time) {
 	cookie := new(http.Cookie)
 	cookie.Name = "token"
@@ -75,6 +92,9 @@ func (u *CookieUtilsImpl) UpdateAuthCookie(c echo.Context, tokenString string, e
 }
 
 // DelAuthCookie - 認証用のCookieを削除
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
 func (u *CookieUtilsImpl) DelAuthCookie(c echo.Context) {
 	cookie := new(http.Cookie)
 	cookie.Name = "token"
@@ -93,6 +113,14 @@ func (u *CookieUtilsImpl) DelAuthCookie(c echo.Context) {
 }
 
 // GetUserIdFromToken - JWTトークンを解析してユーザーIDを取得
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenString: 解析対象のJWTトークン文字列
+//
+// 戻り値:
+//   - string: トークンから取得したユーザーID
+//   - error: トークンが無効または有効期限切れの場合のエラー
 func (u *CookieUtilsImpl) GetUserIdFromToken(c echo.Context, tokenString string) (string, error) {
 	claims, err := u.VerifyToken(c, tokenString)
 	if err != nil {

--- a/backend/utils/cookie/cookie_visitId_di.go
+++ b/backend/utils/cookie/cookie_visitId_di.go
@@ -14,6 +14,10 @@ import (
 )
 
 // CreateVisitIdToken - visitId用JWTトークンを作成
+//
+// 戻り値:
+//   - string: 生成したvisitId用JWTトークン文字列
+//   - error: トークンの署名に失敗した場合のエラー
 func (u *CookieUtilsImpl) CreateVisitIdToken() (string, error) {
 	// 一意の訪問者IDを生成
 	visitorID := uuid.New().String()
@@ -42,6 +46,11 @@ func (u *CookieUtilsImpl) CreateVisitIdToken() (string, error) {
 }
 
 // AddVisitIdCoookie - 訪問者IDを生成
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenString: Cookieに保存するvisitId用JWTトークン文字列
+//   - expirationTime: Cookieの有効期限
 func (u *CookieUtilsImpl) AddVisitIdCoookie(c echo.Context, tokenString string, expirationTime time.Time) {
 	cookie := new(http.Cookie)
 	cookie.Name = "visit-id-token"
@@ -60,6 +69,14 @@ func (u *CookieUtilsImpl) AddVisitIdCoookie(c echo.Context, tokenString string, 
 }
 
 // GetVisitIdFromToken - 訪問者IDを取得
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenString: 解析対象のvisitId用JWTトークン文字列
+//
+// 戻り値:
+//   - string: トークンから取得した訪問者ID
+//   - error: トークンが無効または有効期限切れの場合のエラー
 func (u *CookieUtilsImpl) GetVisitIdFromToken(c echo.Context, tokenString string) (string, error) {
 	claims := &models.ClaimsVisitId{}
 	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {

--- a/backend/utils/cookie/utils_cookie.go
+++ b/backend/utils/cookie/utils_cookie.go
@@ -8,7 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// 認証用のCookieを追加
+// AddAuthCookie は認証用のCookieを追加する。
 func AddAuthCookie(c echo.Context, tokenString string, expirationTime time.Time) {
 	cookie := new(http.Cookie)
 	cookie.Name = "token"
@@ -26,7 +26,7 @@ func AddAuthCookie(c echo.Context, tokenString string, expirationTime time.Time)
 	c.SetCookie(cookie)
 }
 
-// 認証用のCookieを削除
+// DelAuthCookie は認証用のCookieを削除する。
 func DelAuthCookie(c echo.Context) {
 	cookie := new(http.Cookie)
 	cookie.Name = "token"

--- a/backend/utils/cookie/utils_cookie.go
+++ b/backend/utils/cookie/utils_cookie.go
@@ -9,6 +9,11 @@ import (
 )
 
 // AddAuthCookie は認証用のCookieを追加する。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - tokenString: Cookieに保存するJWTトークン文字列
+//   - expirationTime: Cookieの有効期限
 func AddAuthCookie(c echo.Context, tokenString string, expirationTime time.Time) {
 	cookie := new(http.Cookie)
 	cookie.Name = "token"
@@ -27,6 +32,9 @@ func AddAuthCookie(c echo.Context, tokenString string, expirationTime time.Time)
 }
 
 // DelAuthCookie は認証用のCookieを削除する。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
 func DelAuthCookie(c echo.Context) {
 	cookie := new(http.Cookie)
 	cookie.Name = "token"

--- a/backend/utils/log/utils_log.go
+++ b/backend/utils/log/utils_log.go
@@ -31,16 +31,28 @@ func logWithLevel(c echo.Context, level string, message string) {
 }
 
 // LogInfo は情報ログを出力する。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - message: 出力するログメッセージ
 func LogInfo(c echo.Context, message string) {
 	logWithLevel(c, "INFO", message)
 }
 
 // LogError はエラーログを出力する。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - message: 出力するログメッセージ
 func LogError(c echo.Context, message string) {
 	logWithLevel(c, "ERROR", message)
 }
 
 // LogDebug はデバッグログを出力する。
+//
+// 引数:
+//   - c: Echoのリクエストコンテキスト
+//   - message: 出力するログメッセージ
 func LogDebug(c echo.Context, message string) {
 	logWithLevel(c, "DEBUG", message)
 }

--- a/backend/utils/log/utils_log.go
+++ b/backend/utils/log/utils_log.go
@@ -30,17 +30,17 @@ func logWithLevel(c echo.Context, level string, message string) {
 	}
 }
 
-// 情報ログ
+// LogInfo は情報ログを出力する。
 func LogInfo(c echo.Context, message string) {
 	logWithLevel(c, "INFO", message)
 }
 
-// エラーログ
+// LogError はエラーログを出力する。
 func LogError(c echo.Context, message string) {
 	logWithLevel(c, "ERROR", message)
 }
 
-// デバッグログ
+// LogDebug はデバッグログを出力する。
 func LogDebug(c echo.Context, message string) {
 	logWithLevel(c, "DEBUG", message)
 }


### PR DESCRIPTION
## 概要

Go コードの godoc を整備した。2段階の変更を含む。

1. **全公開識別子に godoc コメントを付与・形式統一**（識別子名で始まる規約に統一。既存の日本語コメントは意味を保持して書き換え、未記載箇所は新規追加）
2. **公開関数・メソッドに「引数/戻り値」ブロックを追記**（Go 1.19 リスト構文。`@param`/`@return` は Go に存在しないため、`引数:` / `戻り値:` 見出し + リストで同等の情報を表現。godoc / pkg.go.dev でリストとして整形表示される）

## 変更内容

| グループ | 識別子コメント | 引数/戻り値ブロック |
|---|---|---|
| core（config/supabase/logger/middlewares/routes/models） | 16 | 4 |
| handlers | 31 | 27 |
| services | 58 | 63 |
| repositories | 55 | 60 |
| utils | 21 | 45 |
| **合計** | **181** | **199** |

- 55 files changed。**コメントの追加/追記のみ**で、ロジック・シグネチャ・import は一切変更なし（diff 検査でコメント以外の増減ゼロを確認済み）。
- 型・var・const は引数/戻り値を持たないため、ブロックは付けず要約コメントのみ。
- 引数なしの関数は「引数:」を省略し「戻り値:」のみ記載。
- インターフェースの各メソッド・mock メソッドにもブロックを付与。

### レンダリング例（`go doc`）

```
// FetchBlogById は指定されたIDに一致するブログデータを取得する。
//
// 引数:
//   - id: 取得対象のブログID
//
// 戻り値:
//   - *models.BlogData: 見つかったブログデータ
//   - error: 取得に失敗した場合のエラー
```

## 検証結果（すべて green）

- `go build ./...`: exit 0
- `go vet ./...`: exit 0
- ユニットテスト（`go test ./handlers/... ./services/...`）: 全 PASS
- `gofmt -l`: 未整形 0
- `golint` doc 残件: 0
- `go doc` で引数/戻り値がリスト整形されることを確認

## ドキュメント影響

godoc コメントの追加のみで API 仕様・データ構造・アーキテクチャ等の**振る舞いや記載内容に変更はない**ため、`docs/` の更新は不要（documentation 影響マップの該当なし）。

## 補足（フォローアップ候補・本 PR 対象外）

`.golangci.yml` に `revive` の `exported` ルールを追加すれば、今後の godoc 不足を CI で恒久検出できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)