### PR TITLE
test: API-E2E を新規実装しtestcontainers・CIに導入

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -24,13 +24,16 @@ globs:
 
 | テスト種別 | ツール |
 |-----------|--------|
-| ユニットテスト | Go testing（テーブルドリブン） |
-| インテグレーションテスト | httptest + testcontainers |
-| スモークテスト | scripts/smoke-test.sh |
+| ユニットテスト（UT） | Go testing（テーブルドリブン）。外部I/Oのみモック |
+| インテグレーションテスト（IT） | testcontainers（実DB）。`//go:build integration` |
+| E2E（API-E2E） | httptest + testcontainers。`//go:build e2e`。実サーバー起動 → HTTP フロー検証 |
+| スモークテスト | scripts/smoke-test.sh（未実装） |
+
+共有ヘルパー `backend/testsupport`（build tag `integration || e2e`）が testcontainers の PostgreSQL 起動・スキーマ/シード適用・接続を担う。IT/E2E とも Docker 稼働が前提で、`SUPABASE_URL` を指定した場合のみ実DBへ接続する。
 
 ## テストファイル配置
 
 Go 標準どおりユニット / インテグレーションテストを**対象と同じパッケージにコロケートする**:
 
 - **ユニット / インテグレーションテスト**: 対象と同階層に `_test.go`（例: `handler.go` → `handler_test.go`）。インテグレーションはビルドタグ（例: `//go:build integration`）で分離してよい
-- **E2E テスト**: `e2e/` に集約
+- **E2E テスト**: `e2e/` に集約（`//go:build e2e`）。`config` が起動時に `JWT_SECRET_KEY` を要求するため、実行時に env で渡す

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,25 @@ jobs:
         working-directory: backend
         # SUPABASE_URL は設定しない → testsupport がコンテナを起動する。
         run: go test -tags=integration ./repositories/...
+
+  # E2E テスト。httptest で起動した実サーバー（全ルート）へ HTTP を投げ、
+  # Handler → Service → Repository → DB を貫くフローを検証する。
+  # DB は testcontainers の使い捨て PostgreSQL を再利用する。
+  # config パッケージが起動時に JWT_SECRET_KEY を要求するため env で注入する。
+  e2e-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+
+      - name: go test (e2e / testcontainers)
+        working-directory: backend
+        env:
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+        # SUPABASE_URL は設定しない → testsupport がコンテナを起動する。
+        run: go test -tags=e2e ./e2e/...

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -3,9 +3,10 @@
 version: "2"
 
 run:
-  # integration build tag を付けた IT（repositories/**）も静的解析の対象に含める。
+  # build tag を付けた IT（repositories/**）・E2E（e2e/**）も静的解析の対象に含める。
   build-tags:
     - integration
+    - e2e
 
 linters:
   # v2 のデフォルト（errcheck, govet, ineffassign, staticcheck, unused）に

--- a/backend/e2e/auth_flow_test.go
+++ b/backend/e2e/auth_flow_test.go
@@ -1,0 +1,75 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// 正常系: ログイン → 認証確認 → ログアウト → 認証確認(未認証) の一連フロー。
+func TestE2E_AuthFlow(t *testing.T) {
+	client := newClient(t)
+
+	// ログイン → 200 + token Cookie
+	loginResp := doJSON(t, client, http.MethodPost, "/api/users/login", map[string]string{
+		"email":    os.Getenv("TEST_USER_EMAIL"),
+		"password": os.Getenv("TEST_USER_PASSWD"),
+	})
+	defer loginResp.Body.Close()
+	assert.Equal(t, http.StatusOK, loginResp.StatusCode)
+
+	// 認証確認 → 200 + ユーザー情報（Cookie が引き継がれる）
+	checkResp := doJSON(t, client, http.MethodGet, "/api/users/auth-check", nil)
+	assert.Equal(t, http.StatusOK, checkResp.StatusCode)
+	var checkBody map[string]string
+	decodeBody(t, checkResp, &checkBody)
+	assert.Equal(t, os.Getenv("TEST_USER_EMAIL"), checkBody["email"])
+	assert.Equal(t, os.Getenv("TEST_USER_ID"), checkBody["user_id"])
+
+	// ログアウト → 200
+	logoutResp := doJSON(t, client, http.MethodPost, "/api/users/logout", nil)
+	defer logoutResp.Body.Close()
+	assert.Equal(t, http.StatusOK, logoutResp.StatusCode)
+
+	// ログアウト後の認証確認 → 401
+	afterResp := doJSON(t, client, http.MethodGet, "/api/users/auth-check", nil)
+	defer afterResp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, afterResp.StatusCode)
+}
+
+// 準正常系: 誤ったパスワードでのログインは 401。
+func TestE2E_Login_WrongPassword(t *testing.T) {
+	client := newClient(t)
+
+	resp := doJSON(t, client, http.MethodPost, "/api/users/login", map[string]string{
+		"email":    os.Getenv("TEST_USER_EMAIL"),
+		"password": "wrong-password",
+	})
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// 準正常系: email/password 欠落は 400。
+func TestE2E_Login_MissingFields(t *testing.T) {
+	client := newClient(t)
+
+	resp := doJSON(t, client, http.MethodPost, "/api/users/login", map[string]string{})
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// 準正常系: Cookie 無しでの認証確認は 401。
+func TestE2E_CheckAuth_NoCookie(t *testing.T) {
+	client := newClient(t)
+
+	resp := doJSON(t, client, http.MethodGet, "/api/users/auth-check", nil)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}

--- a/backend/e2e/blogs_crud_test.go
+++ b/backend/e2e/blogs_crud_test.go
@@ -1,0 +1,83 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// 正常系: 認証あり CRUD（作成 → 詳細取得 → 更新 → 削除）の一連フロー。
+func TestE2E_BlogCRUD(t *testing.T) {
+	client := newClient(t)
+	login(t, client)
+
+	// 作成 → 201
+	createResp := doJSON(t, client, http.MethodPost, "/api/blogs/create", map[string]string{
+		"title":       "E2E Blog",
+		"githubUrl":   "https://github.com/test/e2e",
+		"category":    "E2E",
+		"description": "created by e2e test",
+		"tags":        "e2e,go",
+	})
+	assert.Equal(t, http.StatusCreated, createResp.StatusCode)
+	var created struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	}
+	decodeBody(t, createResp, &created)
+	assert.NotEmpty(t, created.ID)
+	assert.Equal(t, "E2E Blog", created.Title)
+
+	// 詳細取得 → 200
+	detailResp := doJSON(t, client, http.MethodGet, "/api/blogs/detail/"+created.ID, nil)
+	assert.Equal(t, http.StatusOK, detailResp.StatusCode)
+	var fetched struct {
+		Title string `json:"title"`
+	}
+	decodeBody(t, detailResp, &fetched)
+	assert.Equal(t, "E2E Blog", fetched.Title)
+
+	// 更新 → 200
+	updateResp := doJSON(t, client, http.MethodPut, "/api/blogs/update/"+created.ID, map[string]string{
+		"title":       "E2E Blog Updated",
+		"githubUrl":   "https://github.com/test/e2e",
+		"category":    "E2E",
+		"description": "updated by e2e test",
+		"tags":        "e2e,go",
+	})
+	assert.Equal(t, http.StatusOK, updateResp.StatusCode)
+	var updated struct {
+		Title string `json:"title"`
+	}
+	decodeBody(t, updateResp, &updated)
+	assert.Equal(t, "E2E Blog Updated", updated.Title)
+
+	// 削除 → 204
+	deleteResp := doJSON(t, client, http.MethodDelete, "/api/blogs/delete/"+created.ID, nil)
+	defer deleteResp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, deleteResp.StatusCode)
+
+	// 削除後の詳細取得 → 404
+	afterResp := doJSON(t, client, http.MethodGet, "/api/blogs/detail/"+created.ID, nil)
+	defer afterResp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, afterResp.StatusCode)
+}
+
+// 準正常系: 未認証でのブログ作成は 401。
+func TestE2E_CreateBlog_Unauthorized(t *testing.T) {
+	client := newClient(t)
+
+	resp := doJSON(t, client, http.MethodPost, "/api/blogs/create", map[string]string{
+		"title":       "no auth",
+		"githubUrl":   "https://github.com/test/x",
+		"category":    "x",
+		"description": "x",
+		"tags":        "x",
+	})
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}

--- a/backend/e2e/blogs_read_test.go
+++ b/backend/e2e/blogs_read_test.go
@@ -1,0 +1,59 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// 正常系: ブログ参照系エンドポイント（一覧・詳細・カテゴリ・タグ・人気）。
+func TestE2E_BlogsRead(t *testing.T) {
+	client := newClient(t)
+
+	// 一覧 → 200、シード2件以上
+	listResp := doJSON(t, client, http.MethodGet, "/api/blogs", nil)
+	assert.Equal(t, http.StatusOK, listResp.StatusCode)
+	var blogs []map[string]any
+	decodeBody(t, listResp, &blogs)
+	assert.GreaterOrEqual(t, len(blogs), 2)
+
+	// 詳細 → 200、シードのタイトル
+	detailResp := doJSON(t, client, http.MethodGet, "/api/blogs/detail/"+os.Getenv("TEST_BLOG_ID"), nil)
+	assert.Equal(t, http.StatusOK, detailResp.StatusCode)
+	var blog map[string]any
+	decodeBody(t, detailResp, &blog)
+	assert.Equal(t, "Test Blog Title", blog["title"])
+
+	// カテゴリ → 200、"Tech" を含む
+	catResp := doJSON(t, client, http.MethodGet, "/api/blogs/categories", nil)
+	assert.Equal(t, http.StatusOK, catResp.StatusCode)
+	var categories []string
+	decodeBody(t, catResp, &categories)
+	assert.Contains(t, categories, "Tech")
+
+	// タグ → 200、非空
+	tagResp := doJSON(t, client, http.MethodGet, "/api/blogs/tags", nil)
+	assert.Equal(t, http.StatusOK, tagResp.StatusCode)
+	var tags []string
+	decodeBody(t, tagResp, &tags)
+	assert.NotEmpty(t, tags)
+
+	// 人気 → 200
+	popResp := doJSON(t, client, http.MethodGet, "/api/blogs/popular/10", nil)
+	defer popResp.Body.Close()
+	assert.Equal(t, http.StatusOK, popResp.StatusCode)
+}
+
+// 準正常系: 存在しない（が UUID 形式は正しい）ID の詳細取得は 404。
+func TestE2E_BlogDetail_NotFound(t *testing.T) {
+	client := newClient(t)
+
+	resp := doJSON(t, client, http.MethodGet, "/api/blogs/detail/00000000-0000-0000-0000-000000000000", nil)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}

--- a/backend/e2e/doc.go
+++ b/backend/e2e/doc.go
@@ -1,0 +1,13 @@
+// Package e2e はバックエンド API の E2E（エンドツーエンド）テストを集約する。
+//
+// 実サーバー（全ルート）を httptest で起動し、HTTP リクエストを通じて
+// Handler → Service → Repository → DB を貫くフローを検証する。
+// DB は testsupport（testcontainers の使い捨て PostgreSQL）を再利用する。
+//
+// テスト本体は `//go:build e2e` で分離しており、実行は次のとおり:
+//
+//	JWT_SECRET_KEY=... go test -tags=e2e ./e2e/...
+//
+// このファイル（build tag なし）は、デフォルトビルドでも e2e パッケージを
+// 有効に保つためのプレースホルダであり、テストコードは含まない。
+package e2e

--- a/backend/e2e/health_test.go
+++ b/backend/e2e/health_test.go
@@ -1,0 +1,25 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// 正常系: ヘルスチェック GET / が 200 で "Service is running" を返す。
+func TestE2E_Health(t *testing.T) {
+	client := newClient(t)
+
+	resp := doJSON(t, client, http.MethodGet, "/", nil)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "Service is running", string(body))
+}

--- a/backend/e2e/helpers_test.go
+++ b/backend/e2e/helpers_test.go
@@ -1,0 +1,75 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"os"
+	"testing"
+)
+
+// newClient は Cookie を保持する HTTP クライアントを生成する。
+// ログインで受け取る token / visit-id-token Cookie を後続リクエストへ引き継ぐために用いる。
+func newClient(t *testing.T) *http.Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("failed to create cookie jar: %v", err)
+	}
+	return &http.Client{Jar: jar}
+}
+
+// doJSON は baseURL に対して method/path のリクエストを送る。
+// body が非 nil の場合は JSON エンコードして送信する。レスポンスは呼び出し側で Close する。
+func doJSON(t *testing.T, client *http.Client, method, path string, body any) *http.Response {
+	t.Helper()
+
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("failed to marshal body: %v", err)
+		}
+		reader = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequest(method, baseURL+path, reader)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed (%s %s): %v", method, path, err)
+	}
+	return resp
+}
+
+// decodeBody はレスポンスボディを dst にデコードし、ボディを Close する。
+func decodeBody(t *testing.T, resp *http.Response, dst any) {
+	t.Helper()
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+}
+
+// login はシード済みユーザーでログインし、token Cookie を client に保存する。
+func login(t *testing.T, client *http.Client) {
+	t.Helper()
+	resp := doJSON(t, client, http.MethodPost, "/api/users/login", map[string]string{
+		"email":    os.Getenv("TEST_USER_EMAIL"),
+		"password": os.Getenv("TEST_USER_PASSWD"),
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("login failed: status=%d", resp.StatusCode)
+	}
+}

--- a/backend/e2e/likes_comments_test.go
+++ b/backend/e2e/likes_comments_test.go
@@ -1,0 +1,67 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// 正常系（いいね）: 訪問者ID発行 → いいね作成 → 状態確認 → 削除 の一連フロー。
+func TestE2E_BlogLikeFlow(t *testing.T) {
+	client := newClient(t)
+	blogID := os.Getenv("TEST_BLOG_ID")
+
+	// 訪問者ID発行 → 200（visit-id-token Cookie を保存）
+	genResp := doJSON(t, client, http.MethodGet, "/api/blog-likes/generate-visit-id", nil)
+	defer genResp.Body.Close()
+	assert.Equal(t, http.StatusOK, genResp.StatusCode)
+
+	// いいね作成 → 200
+	createResp := doJSON(t, client, http.MethodPost, "/api/blog-likes/create/"+blogID, nil)
+	defer createResp.Body.Close()
+	assert.Equal(t, http.StatusOK, createResp.StatusCode)
+
+	// いいね状態確認 → 200 かつ isLiked=true
+	isLikedResp := doJSON(t, client, http.MethodGet, "/api/blog-likes/is-liked/"+blogID, nil)
+	assert.Equal(t, http.StatusOK, isLikedResp.StatusCode)
+	var liked map[string]bool
+	decodeBody(t, isLikedResp, &liked)
+	assert.True(t, liked["isLiked"])
+
+	// いいね削除 → 200
+	deleteResp := doJSON(t, client, http.MethodDelete, "/api/blog-likes/delete/"+blogID, nil)
+	defer deleteResp.Body.Close()
+	assert.Equal(t, http.StatusOK, deleteResp.StatusCode)
+}
+
+// 正常系（コメント）: コメント一覧取得 → コメント作成。
+func TestE2E_CommentFlow(t *testing.T) {
+	client := newClient(t)
+	blogID := os.Getenv("TEST_BLOG_ID")
+
+	// 一覧取得 → 200（シード済みコメントを含む）
+	listResp := doJSON(t, client, http.MethodGet, "/api/comments/blog/"+blogID, nil)
+	assert.Equal(t, http.StatusOK, listResp.StatusCode)
+	var comments []map[string]any
+	decodeBody(t, listResp, &comments)
+	assert.GreaterOrEqual(t, len(comments), 1)
+
+	// 作成 → 201
+	createResp := doJSON(t, client, http.MethodPost, "/api/comments/create", map[string]string{
+		"blogId":    blogID,
+		"guestUser": "E2E Guest",
+		"comment":   "e2e comment",
+	})
+	assert.Equal(t, http.StatusCreated, createResp.StatusCode)
+	var created struct {
+		ID      string `json:"id"`
+		Comment string `json:"comment"`
+	}
+	decodeBody(t, createResp, &created)
+	assert.NotEmpty(t, created.ID)
+	assert.Equal(t, "e2e comment", created.Comment)
+}

--- a/backend/e2e/main_test.go
+++ b/backend/e2e/main_test.go
@@ -1,0 +1,49 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"backend/middlewares"
+	"backend/routes"
+	"backend/testsupport"
+
+	"github.com/labstack/echo/v4"
+)
+
+// baseURL は httptest で起動した E2E 用サーバーのベース URL。各テストから参照する。
+var baseURL string
+
+// TestMain は E2E の前準備を行う:
+//  1. testsupport.Setup でテスト用 DB（既定は testcontainers）を準備し supabase.Pool を接続
+//  2. middlewares/routes で本番同等の Echo アプリを組み立て
+//  3. httptest でサーバーを起動し baseURL を公開
+//
+// 注意: config パッケージが起動時（init）に JWT_SECRET_KEY を要求するため、
+// バイナリ起動時に環境変数として JWT_SECRET_KEY を渡すこと。
+func TestMain(m *testing.M) {
+	teardown, err := testsupport.Setup()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "e2e: DB setup failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	// 本番と同じ組み立て（ミドルウェア + ルーティング）。Repository は supabase.Pool を参照する。
+	e := echo.New()
+	middlewares.SetupMiddlewares(e)
+	routes.SetupRoutes(e)
+
+	srv := httptest.NewServer(e)
+	baseURL = srv.URL
+
+	code := m.Run()
+
+	// os.Exit は defer を実行しないため明示的に後始末する。
+	srv.Close()
+	teardown()
+	os.Exit(code)
+}

--- a/backend/testsupport/testdb.go
+++ b/backend/testsupport/testdb.go
@@ -1,6 +1,6 @@
-//go:build integration
+//go:build integration || e2e
 
-// Package testsupport は Repository 層の IT（インテグレーションテスト）向けに
+// Package testsupport は Repository 層の IT および API-E2E 向けに
 // PostgreSQL のテスト用 DB を提供する。
 //
 // 動作は環境変数 SUPABASE_URL の有無で切り替わる（判定は実環境変数のみ。
@@ -8,11 +8,11 @@
 // コンテナ経路を意図せず乗っ取るのを防ぐため）:
 //   - SUPABASE_URL が設定済み: その DB をそのまま使う（実 Supabase 等）。
 //     この場合、呼び出し側が TEST_* も併せて指定すること。
-//   - 未設定（既定）: testcontainers で使い捨ての PostgreSQL コンテナを起動し、
+//   - 未設定（既定）: testcontainers で使い捨ての PostgreSQL を起動し、
 //     schema.sql / seed.sql を適用し、TEST_* をフィクスチャ値に設定してから接続する。
 //
-// build tag 'integration' を付けているため、通常の `go test ./...`（単体テスト）や
-// 本番ビルドには含まれない。IT は `go test -tags=integration ./repositories/...` で実行する。
+// build tag 'integration'（IT）/ 'e2e'（E2E）を付けているため、通常の
+// `go test ./...`（単体テスト）や本番ビルドには含まれない。
 package testsupport
 
 import (
@@ -41,7 +41,7 @@ const (
 )
 
 // Start は TestMain から呼び出し、テスト用 DB を準備して m.Run() を実行する。
-// 戻り値の終了コードを TestMain 側で os.Exit に渡すこと。
+// 戻り値の終了コードを TestMain 側で os.Exit に渡すこと（IT 向けの薄いラッパ）。
 //
 // 引数:
 //   - m: テストのエントリポイント（*testing.M）
@@ -49,6 +49,23 @@ const (
 // 戻り値:
 //   - int: m.Run() の終了コード（準備失敗時は 1）
 func Start(m *testing.M) int {
+	teardown, err := Setup()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "testsupport: %v\n", err)
+		return 1
+	}
+	defer teardown()
+	return m.Run()
+}
+
+// Setup はテスト用 DB を準備し、後始末を行う teardown 関数を返す。
+// E2E のように m.Run() の前後で追加のセットアップ（サーバ起動等）を挟みたい
+// 場合に用いる。DB 準備に失敗した場合はエラーを返す（コンテナは破棄済み）。
+//
+// 戻り値:
+//   - func(): プール close とコンテナ破棄を行う後始末関数（成功時のみ非 nil）
+//   - error: DB 準備に失敗した場合のエラー
+func Setup() (func(), error) {
 	root := moduleRoot()
 
 	logger.InitLogger()
@@ -56,11 +73,9 @@ func Start(m *testing.M) int {
 	// SUPABASE_URL が実環境変数として指定済みなら、その DB をそのまま使う。
 	if os.Getenv("SUPABASE_URL") != "" {
 		if err := supabase.InitSupabase(); err != nil {
-			fmt.Fprintf(os.Stderr, "testsupport: supabase init failed (SUPABASE_URL): %v\n", err)
-			return 1
+			return nil, fmt.Errorf("supabase init failed (SUPABASE_URL): %w", err)
 		}
-		defer supabase.ClosePool()
-		return m.Run()
+		return func() { supabase.ClosePool() }, nil
 	}
 
 	// 未指定なら testcontainers で PostgreSQL を起動する。
@@ -80,20 +95,19 @@ func Start(m *testing.M) int {
 		),
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "testsupport: failed to start postgres container: %v\n", err)
-		return 1
+		return nil, fmt.Errorf("failed to start postgres container: %w", err)
 	}
-	defer func() { _ = container.Terminate(ctx) }()
+	terminate := func() { _ = container.Terminate(ctx) }
 
 	host, err := container.Host(ctx)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "testsupport: failed to get container host: %v\n", err)
-		return 1
+		terminate()
+		return nil, fmt.Errorf("failed to get container host: %w", err)
 	}
 	port, err := container.MappedPort(ctx, "5432/tcp")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "testsupport: failed to get mapped port: %v\n", err)
-		return 1
+		terminate()
+		return nil, fmt.Errorf("failed to get mapped port: %w", err)
 	}
 
 	// アプリの接続経路（supabase.InitSupabase）と TEST_* を環境変数で供給する。
@@ -109,18 +123,20 @@ func Start(m *testing.M) int {
 	}
 	for k, v := range envs {
 		if err := os.Setenv(k, v); err != nil {
-			fmt.Fprintf(os.Stderr, "testsupport: failed to set env %s: %v\n", k, err)
-			return 1
+			terminate()
+			return nil, fmt.Errorf("failed to set env %s: %w", k, err)
 		}
 	}
 
 	if err := supabase.InitSupabase(); err != nil {
-		fmt.Fprintf(os.Stderr, "testsupport: supabase init failed (container): %v\n", err)
-		return 1
+		terminate()
+		return nil, fmt.Errorf("supabase init failed (container): %w", err)
 	}
-	defer supabase.ClosePool()
 
-	return m.Run()
+	return func() {
+		supabase.ClosePool()
+		terminate()
+	}, nil
 }
 
 // moduleRoot は現在の作業ディレクトリから上方向へ go.mod を探索し、

--- a/docs/08-test-specification.md
+++ b/docs/08-test-specification.md
@@ -40,19 +40,21 @@
 
 | テストレベル | 対象層 | テスト種別 | DB接続 | モック使用 |
 |-------------|--------|-----------|--------|-----------|
+| E2E テスト | 全層（HTTP→Handler→Service→Repository→DB） | エンドツーエンド（E2E） | 必要（既定は testcontainers。`SUPABASE_URL` 指定時は実DB） | なし（実サーバーを httptest で起動） |
 | Repository テスト | Repository層 | インテグレーション（IT） | 必要（既定は testcontainers の使い捨て PostgreSQL。`SUPABASE_URL` 指定時は実DB） | なし |
 | Service テスト | Service層 | 単体テスト（UT） | 不要 | Repository モック |
 | Handler テスト | Handler層 | 単体テスト（UT） | 不要 | Service モック + Cookie モック |
 
-> IT は `//go:build integration` タグで分離しており、実行は `go test -tags=integration ./repositories/...`。通常の `go test ./...`（UT）には含まれない。
+> IT は `//go:build integration`、E2E は `//go:build e2e` タグで分離しており、実行は `go test -tags=integration ./repositories/...` / `go test -tags=e2e ./e2e/...`。通常の `go test ./...`（UT）には含まれない。
 
 ### テストピラミッド
 
 ```
-        /  Handler テスト  \        ← HTTPリクエスト/レスポンスの検証
-       / Service テスト      \      ← ビジネスロジックの検証
-      / Repository テスト      \    ← データアクセスの検証（testcontainers / 実DB）
-     /_________________________\
+        /    E2E テスト     \        ← 実サーバーへの HTTP フロー検証（testcontainers / 実DB）
+       /  Handler テスト     \       ← HTTPリクエスト/レスポンスの検証
+      /  Service テスト        \     ← ビジネスロジックの検証
+     / Repository テスト         \   ← データアクセスの検証（testcontainers / 実DB）
+    /_____________________________\
 ```
 
 ---
@@ -454,6 +456,41 @@ func TestHandler_FetchBlogs(t *testing.T) {
 | 認証エラー | Cookie未設定時の401レスポンス |
 | バリデーションエラー | 不正パラメータ時の400レスポンス |
 
+### 6.4 E2E テスト（API-E2E）
+
+#### 概要
+
+- `httptest.NewServer` で本番同等の Echo アプリ（`middlewares.SetupMiddlewares` + `routes.SetupRoutes`）を起動し、**実 HTTP リクエスト**で `Handler → Service → Repository → DB` を貫くフローを検証する。
+- DB は `testsupport`（既定は testcontainers の使い捨て PostgreSQL）を再利用。モックは使わない。
+- `http.Client` + `cookiejar` で認証 Cookie（`token` / `visit-id-token`）をリクエスト間で引き継ぐ。
+- 範囲は**正常系 + 準正常系**（純異常系は対象外）。
+- `//go:build e2e` で分離。実行は `JWT_SECRET_KEY=... go test -tags=e2e ./e2e/...`。
+
+> `config` パッケージが**起動時（init）**に `JWT_SECRET_KEY` を要求するため、E2E はバイナリ起動時に環境変数として渡す必要がある。
+
+#### テストファイル（`e2e/`）
+
+| ファイル | 検証フロー |
+|---------|-----------|
+| `main_test.go` | TestMain（`testsupport.Setup` + httptest サーバ起動） |
+| `helpers_test.go` | HTTP クライアント/リクエスト/ログインの共通ヘルパ |
+| `health_test.go` | 正常系: `GET /` → 200 |
+| `auth_flow_test.go` | 正常系: login→auth-check→logout→auth-check(401) / 準正常系: 誤パスワード401・欠落400・Cookie無し401 |
+| `blogs_read_test.go` | 正常系: 一覧・詳細・カテゴリ・タグ・人気 / 準正常系: 存在しないID → 404 |
+| `blogs_crud_test.go` | 正常系: 作成(201)→詳細→更新(200)→削除(204) / 準正常系: 未認証作成 → 401 |
+| `likes_comments_test.go` | 正常系: 訪問者ID発行→いいね作成/確認/削除、コメント一覧/作成(201) |
+
+#### 主なエンドポイントの期待ステータス（E2E で確定）
+
+| 操作 | 期待 |
+|------|------|
+| ログイン成功 / 失敗 / 欠落 | 200 / 401 / 400 |
+| ブログ作成（認証） / 未認証 | 201 / 401 |
+| ブログ更新 / 削除 | 200 / **204** |
+| ブログ詳細（存在しないID） | 404 |
+| いいね 作成 / 削除 / 状態確認 | 200 / 200 / 200 |
+| コメント 作成 / 一覧 | 201 / 200 |
+
 ---
 
 ## 7. テスト実行方法
@@ -468,9 +505,12 @@ go test ./... -v
 
 # IT（Repository層 / testcontainers。Docker 稼働が前提）
 go test -tags=integration ./repositories/... -v
+
+# E2E（API-E2E / testcontainers。Docker 稼働が前提。JWT_SECRET_KEY を env で渡す）
+JWT_SECRET_KEY=your-test-secret go test -tags=e2e ./e2e/... -v
 ```
 
-> `go test ./...`（タグなし）に IT は含まれない（`//go:build integration` で分離）。
+> `go test ./...`（タグなし）に IT・E2E は含まれない（`//go:build integration` / `//go:build e2e` で分離）。
 
 ### 特定パッケージのテスト実行
 

--- a/docs/09-architecture-specification.md
+++ b/docs/09-architecture-specification.md
@@ -375,7 +375,7 @@ GitHub Actions は 2 つのワークフローに責務を分離している。
 
 | ファイル | トリガー | 役割 |
 |---------|---------|------|
-| `.github/workflows/ci.yml` | PR・`main` への push | 品質ゲート（lint / 静的解析 + ユニットテスト + インテグレーションテスト）。マージ前に PR で実行される |
+| `.github/workflows/ci.yml` | PR・`main` への push | 品質ゲート（lint / 静的解析 + UT + IT + E2E）。マージ前に PR で実行される |
 | `.github/workflows/deploy.yml` | `main` への push | Docker ビルド → Artifact Registry へ push → Cloud Run へデプロイ |
 
 > テスト実行は `ci.yml` に一本化している。`deploy.yml` はデプロイ専任で、テスト・Go セットアップは持たない（PR 段階で `ci.yml` が品質を担保済みのため）。
@@ -384,15 +384,16 @@ GitHub Actions は 2 つのワークフローに責務を分離している。
 
 ファイル: `.github/workflows/ci.yml`
 
-PR・`main` への push で実行し、独立した 3 ジョブを並列に走らせる。
+PR・`main` への push で実行し、独立した 4 ジョブを並列に走らせる。
 
 | ジョブ | ステップ | 説明 |
 |-------|---------|------|
 | `lint` | gofmt（`gofmt -l .`）/ go vet / golangci-lint（v2.12.2） | フォーマット・静的解析・統合リンタ |
 | `test` | `go test ./handlers/... ./services/...`（`working-directory: backend`、`JWT_SECRET_KEY` を env で注入） | 全 mock の Handler/Service 層 UT を実行。DB を必要としない |
 | `integration-test` | `go test -tags=integration ./repositories/...`（`working-directory: backend`） | Repository 層の IT を testcontainers（使い捨て PostgreSQL）で実行。実 Supabase には接続しない |
+| `e2e-test` | `go test -tags=e2e ./e2e/...`（`working-directory: backend`、`JWT_SECRET_KEY` を env で注入） | httptest で起動した実サーバーへ HTTP を投げ、Handler→Service→Repository→DB を貫く API-E2E を testcontainers 上で実行 |
 
-> IT は `testsupport` パッケージが testcontainers で PostgreSQL コンテナを起動し、`testsupport/testdata/schema.sql` / `seed.sql` を適用して実行する。GitHub Actions の ubuntu ランナーは Docker 同梱のため追加設定は不要。`SUPABASE_URL` を環境変数で指定した場合のみ、コンテナを起動せずその DB に接続する。
+> IT・E2E とも `testsupport` パッケージが testcontainers で PostgreSQL コンテナを起動し、`testsupport/testdata/schema.sql` / `seed.sql` を適用して実行する。GitHub Actions の ubuntu ランナーは Docker 同梱のため追加設定は不要。`SUPABASE_URL` を環境変数で指定した場合のみ、コンテナを起動せずその DB に接続する。E2E は `config` パッケージが起動時に `JWT_SECRET_KEY` を要求するため env で注入する。
 
 ### 6.1 デプロイワークフロー
 
@@ -706,11 +707,21 @@ backend/
 ├── supabase/                        # Supabase接続管理
 │   └── client.go                   # 接続プール初期化・テストクエリ・クローズ
 │
-├── testsupport/                     # IT（Repository層）共有ヘルパー（build tag: integration）
-│   ├── testdb.go                   # testcontainers 起動 or 実DB接続の切替・TestMain 委譲先
+├── testsupport/                     # IT/E2E 共有ヘルパー（build tag: integration || e2e）
+│   ├── testdb.go                   # testcontainers 起動 or 実DB接続の切替（Setup / Start）
 │   └── testdata/
-│       ├── schema.sql              # IT用スキーマ（コードのテーブル名に一致）
+│       ├── schema.sql              # スキーマ（コードのテーブル名に一致）
 │       └── seed.sql                # 決定的シード（固定UUID）
+│
+├── e2e/                             # API-E2E テスト（build tag: e2e）
+│   ├── doc.go                      # パッケージ宣言（デフォルトビルドで有効化するプレースホルダ）
+│   ├── main_test.go                # TestMain（DB準備 + httptest サーバ起動）
+│   ├── helpers_test.go             # HTTP クライアント/リクエストヘルパ
+│   ├── health_test.go              # ヘルスチェック
+│   ├── auth_flow_test.go           # ログイン→認証確認→ログアウト
+│   ├── blogs_read_test.go          # ブログ参照系
+│   ├── blogs_crud_test.go          # ブログ CRUD（認証あり）
+│   └── likes_comments_test.go      # いいね/コメントフロー
 │
 ├── utils/                           # ユーティリティ
 │   ├── cookie/
@@ -834,9 +845,13 @@ go test ./handlers/... ./services/...
 # インテグレーションテスト（IT / Repository 層）。既定で testcontainers が
 # 使い捨ての PostgreSQL を起動する（Docker 稼働が前提）。
 go test -tags=integration ./repositories/...
+
+# E2E（API-E2E）。実サーバーを起動し HTTP フローを検証（Docker 稼働が前提）。
+# config が起動時に JWT_SECRET_KEY を要求するため env で渡す。
+JWT_SECRET_KEY=... go test -tags=e2e ./e2e/...
 ```
 
-- IT は `//go:build integration` タグで分離されており、通常の `go test ./...` には含まれない。各パッケージの `TestMain` が `backend/testsupport` の `Start` を呼び、コンテナ起動・スキーマ/シード適用・接続を一括で行う。
+- IT は `//go:build integration`、E2E は `//go:build e2e` タグで分離されており、通常の `go test ./...` には含まれない。IT は各パッケージの `TestMain` が `backend/testsupport` の `Start` を、E2E は `main_test.go` が `Setup` を呼び、コンテナ起動・スキーマ/シード適用・接続を一括で行う。
 - IT は `SUPABASE_URL` を環境変数として指定した場合のみ、コンテナを起動せずその DB に接続する（`TEST_*` も併せて指定すること）。`testsupport` は `.env` ファイルを自動読み込みしない（古い `.env.test` によるコンテナ経路の意図しない乗っ取りを防ぐため）。
 - Service / Handler 層テストはモックを使うため DB 不要だが、`config` パッケージの `init` が `JWT_SECRET_KEY` を要求する。
 - CI（`.github/workflows/ci.yml`）は PR・`main` への push で `test` ジョブ（UT）と `integration-test` ジョブ（IT / testcontainers）を `working-directory: backend` で実行する。詳細は [`08-test-specification.md`](08-test-specification.md)。

--- a/docs/11-tasks.md
+++ b/docs/11-tasks.md
@@ -146,6 +146,12 @@
   - `supabase/client.go` の sslmode を `DB_SSLMODE`（既定 `require`）で環境変数化
   - CI（`ci.yml`）に `integration-test` ジョブを追加（`go test -tags=integration ./repositories/...`）
 
+- [x] **E2E（API-E2E）の実装・CI 導入**
+  - `httptest` で本番同等の Echo アプリ（middlewares + routes）を起動し、実 HTTP フローで Handler→Service→Repository→DB を検証
+  - DB は `testsupport`（testcontainers）を再利用（`Setup()` を切り出し、build tag を `integration || e2e` に拡張）
+  - `e2e/`（`//go:build e2e`）に集約。範囲は正常系＋準正常系（認証フロー・ブログCRUD・いいね/コメント・ヘルスチェック）
+  - CI（`ci.yml`）に `e2e-test` ジョブを追加（`JWT_SECRET_KEY` を env 注入・`go test -tags=e2e ./e2e/...`）
+
 ## 改善タスク（未着手）
 
 ### セキュリティ（優先度: 高）

--- a/readme.md
+++ b/readme.md
@@ -93,12 +93,16 @@ go test ./handlers/... ./services/...
 # インテグレーションテスト（IT）: repositories 層。
 # 既定では testcontainers が使い捨ての PostgreSQL を起動する（Docker 稼働が前提）。
 go test -tags=integration ./repositories/...
+
+# E2E（API-E2E）: 実サーバーを起動し HTTP フローを検証（Docker 稼働が前提）。
+# config が起動時に JWT_SECRET_KEY を要求するため env で渡す。
+JWT_SECRET_KEY=your-test-secret go test -tags=e2e ./e2e/...
 ```
 
-- IT は `//go:build integration` タグで分離しているため、通常の `go test ./...` には含まれない。
-- IT は既定でコンテナを起動するため `.env.test` は不要。実 DB に対して実行したい場合のみ `SUPABASE_URL`（と `TEST_*`）を環境変数で渡す（[`backend/.env.test.example`](backend/.env.test.example) 参照）。
+- IT は `//go:build integration`、E2E は `//go:build e2e` タグで分離しているため、通常の `go test ./...` には含まれない。
+- IT / E2E は既定でコンテナを起動するため `.env.test` は不要。実 DB に対して実行したい場合のみ `SUPABASE_URL`（と `TEST_*`）を環境変数で渡す（[`backend/.env.test.example`](backend/.env.test.example) 参照）。
 
-> CI（`ci.yml`）は PR・`main` への push で、`test` ジョブ（UT）と `integration-test` ジョブ（IT / testcontainers）の両方を実行する。テスト方針の詳細は [`docs/08-test-specification.md`](docs/08-test-specification.md)。
+> CI（`ci.yml`）は PR・`main` への push で、`test`（UT）・`integration-test`（IT / testcontainers）・`e2e-test`（API-E2E / testcontainers）の各ジョブを実行する。テスト方針の詳細は [`docs/08-test-specification.md`](docs/08-test-specification.md)。
 
 ## Lint / 静的解析
 


### PR DESCRIPTION
## 概要

テストピラミッドの頂点（E2E）が空白だったため、**API-E2E テスト**を新規実装する。`httptest` で本番同等の Echo アプリを起動し、**実 HTTP リクエスト**で `Handler → Service → Repository → DB` を貫くフローを検証する。DB は既存の `testsupport`（testcontainers）を再利用し、CI（PR・push）で自動実行する。

範囲: **正常系 ＋ 準正常系**（純異常系は対象外）。

## 背景

`.claude/rules/testing.md` は「E2E は `e2e/` に集約」と定めていたが**未実装**だった。UT（handlers/services・mock）→ IT（repositories・testcontainers）に続き、本 PR で頂点を充足する。

```
     /    E2E     \      ← 本PRで追加（実サーバー起動 → HTTPフロー）
    /  Handler UT  \
   /  Service UT     \
  / Repository IT      \
 /______________________\
```

## 主な変更

### E2E ハーネス（新規 `backend/e2e/`, `//go:build e2e`）
- `main_test.go`: `testsupport.Setup()` で DB 準備 → `middlewares.SetupMiddlewares` + `routes.SetupRoutes` で全ルート構築 → `httptest.NewServer` 起動。
- `helpers_test.go`: `cookiejar` 付き `http.Client`・JSON リクエスト・ログインの共通ヘルパ。
- フロー別テスト（計11件）:
  - `auth_flow`: login→auth-check→logout→auth-check(401) / 誤パスワード401・欠落400・Cookie無し401
  - `blogs_read`: 一覧・詳細・カテゴリ・タグ・人気 / 存在しないID→404
  - `blogs_crud`: 作成(201)→詳細→更新(200)→削除(204) / 未認証作成→401
  - `likes_comments`: 訪問者ID発行→いいね作成/確認/削除、コメント一覧/作成(201)
  - `health`: `GET /`→200
- `doc.go`（build tag なし）: デフォルトビルドで e2e パッケージを有効に保ち `go vet ./...` を壊さないためのプレースホルダ。

### testsupport 再利用（リファクタ）
- `Start(m)` から DB 準備部を `Setup() (teardown, error)` として切り出し（**IT の呼び出しは不変**）。
- build tag を `integration` → `integration || e2e` に拡張。

### CI / lint
- `ci.yml` に `e2e-test` ジョブ追加（`JWT_SECRET_KEY` を env 注入・`go test -tags=e2e ./e2e/...`）。ubuntu ランナーは Docker 同梱で追加設定不要。
- `.golangci.yml` の `build-tags` に `e2e` を追加。

### ドキュメント同期
- `README.md` / `docs/08`（E2E セクション・ピラミッド）/ `docs/09`（CI 4ジョブ・`e2e/` 構成）/ `docs/11`（実績）/ `.claude/rules/testing.md`。

## 検証（ローカル）
- E2E: `JWT_SECRET_KEY=... go test -tags=e2e -count=1 ./e2e/...` → **緑（11テスト全パス）**
- 非干渉: UT（タグなし）・IT（`-tags=integration`）とも緑を再確認
- `golangci-lint run`（build-tags: integration,e2e）→ 0 issues / `gofmt`・`go vet` 全タグ通過 / `go build ./...` OK

## 留意点
- `config` が起動時（init）に `JWT_SECRET_KEY` を要求するため、E2E は**バイナリ起動時に env で渡す**必要がある（CI ジョブ・手元コマンドで明示）。
- E2E はコンテナ＋サーバ起動分だけ UT/IT より遅いが、CI の並列ジョブで吸収。

🤖 Generated with [Claude Code](https://claude.com/claude-code)