### PR TITLE
chore(rules): 監査列の DB 側自動化ルール(database.md)を追加

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -1,0 +1,50 @@
+# データベース（PostgreSQL / Supabase・pgx 直叩き）
+
+本プロジェクトは ORM を使わず `jackc/pgx` で SQL を直接実行する。ORM が自動で担保する不変条件は、**DB スキーマ側で担保する**（アプリケーションコードの規律に頼らない）。SQL の書き方そのものは [`security.md`](security.md)（インジェクション対策）に従う。
+
+## 監査列
+
+全テーブルに監査列を持たせ、値は **DB 側で自動設定する**。アプリケーションコードで日時を組み立てない。
+
+| 列 | 型 | 既定 | 用途 |
+|---|---|---|---|
+| `created_at` | `timestamptz` | `DEFAULT now() NOT NULL` | 作成日時 |
+| `updated_at` | `timestamptz` | `DEFAULT now() NOT NULL` | 更新日時（UPDATE 時はトリガで自動更新） |
+| `deleted_at` | `timestamptz NULL` | なし | 論理削除日時（要件がある場合のみ） |
+
+- **手動代入を禁止**する。リポジトリ層の INSERT / UPDATE 文に `created_at` / `updated_at` を書かない（`SET updated_at = NOW()` も含む）。`RETURNING` で読み出すのは可。
+- **タイムゾーン付き（`timestamptz`）で統一**する。`timestamp`（タイムゾーンなし）を混在させない。Cloud Run / Supabase / ローカルでコンテナの TZ が異なるため、`timestamp` は暗黙変換で値がずれる。
+- `created_at` は **UPDATE で書き換えない**。更新文の SET 句に含めない。
+- `updated_at` の自動更新は、**共通トリガ関数 + 各テーブルの `BEFORE UPDATE` トリガ**で実現する。テーブルごとに関数を書き写さない。
+
+```sql
+-- 共通トリガ関数（1 つだけ定義する）
+CREATE OR REPLACE FUNCTION set_updated_at() RETURNS trigger AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 監査列を持つ各テーブルに 1 つずつ張る
+CREATE TRIGGER trg_blogs_set_updated_at
+    BEFORE UPDATE ON blogs
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+```
+
+- **例外**: シードデータ・テストで日時を固定したい場合のみ明示指定を許容する。本番コードパス（`repositories/**`）に持ち込まない。
+- 操作ユーザー（`created_by` / `updated_by`）は現時点で要件がないため持たない。導入する場合は、認証ユーザーを `context.Context` で伝搬したうえでリポジトリ層の共通ヘルパーに集約し、ユースケースごとに詰めない。
+
+## スキーマの同期
+
+スキーマ定義は複数箇所に存在するため、**変更時は全てを同一 PR 内で揃える**（片方だけ直すと IT が本番と乖離し、検知能力を失う）。
+
+| ファイル | 役割 |
+|---|---|
+| `backend/testsupport/testdata/schema.sql` | IT / E2E（testcontainers）用スキーマ |
+| `backend/testsupport/testdata/seed.sql` | IT / E2E 用シードデータ |
+| `work/backup.sql` | Supabase 本番のダンプ（参照用） |
+| `docs/05-data-specification.md` | テーブル定義のドキュメント |
+
+- テーブル・列を追加変更したら、`schema.sql` を本番スキーマに一致させる。列の**型まで**一致させる（型の差異は IT をすり抜ける典型的な乖離）。
+- 本番側の変更は Supabase 上のマイグレーションとして適用し、手順を [`docs/supabase-migration-guide.md`](../../docs/supabase-migration-guide.md) に沿って残す。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,3 +19,4 @@ Go + Echo フレームワークで構築されたブログWebアプリケーシ�
 | error-handling.md | 全体 | エラーハンドリング方針（バリデーション・HTTP ステータス・統一レスポンス） |
 | security.md | 全体 | セキュリティ方針（認証・CORS・インジェクション対策・シークレット管理） |
 | api.md | backend/** | Go + Echo API 設計・レイヤー分離（Handler/Service/Repository） |
+| database.md | backend/** | DB 方針（監査列の DB 側自動化・timestamptz 統一・スキーマ同期） |

--- a/docs/05-data-specification.md
+++ b/docs/05-data-specification.md
@@ -22,6 +22,8 @@
   - [6.1 接続パラメータ](#61-接続パラメータ)
   - [6.2 接続ライフサイクル](#62-接続ライフサイクル)
   - [6.3 本番環境での秘密情報管理](#63-本番環境での秘密情報管理)
+- [7. 監査列方針](#7-監査列方針)
+  - [7.1 現状との乖離（未対応）](#71-現状との乖離未対応)
 
 ---
 
@@ -312,3 +314,28 @@ Supabase（PostgreSQL）
 
 - `SUPABASE_URL` はTerraformの `google_secret_manager_secret` リソースとして管理される。
 - Cloud Runのコンテナ環境変数として、Secret Managerから自動注入される。
+
+## 7. 監査列方針
+
+本プロジェクトはORMを使わず `pgx` でSQLを直接実行するため、監査列（`created_at` / `updated_at`）の値は**DB側で自動設定する**方針とする。詳細なルールは [`.claude/rules/database.md`](../.claude/rules/database.md) を参照。
+
+| 列 | あるべき型 | あるべき既定 | 用途 |
+|---|---|---|---|
+| `created_at` | `timestamptz` | `DEFAULT now() NOT NULL` | 作成日時。UPDATE では書き換えない |
+| `updated_at` | `timestamptz` | `DEFAULT now() NOT NULL` + `BEFORE UPDATE` トリガ | 更新日時 |
+
+- リポジトリ層のINSERT / UPDATE文に監査列を書かない（`SET updated_at = NOW()` も含む）。`RETURNING` での読み出しは可。
+- タイムゾーン付き（`timestamptz`）で統一する。Cloud Run / Supabase / ローカルでコンテナのTZが異なるため、`timestamp`（タイムゾーンなし）を混在させると暗黙変換で値がずれる。
+
+### 7.1 現状との乖離（未対応）
+
+現行スキーマは上記方針を満たしておらず、以下の既知の問題がある。
+
+| 問題 | 影響 | 該当箇所 |
+|---|---|---|
+| `updated_at` を更新する `BEFORE UPDATE` トリガが存在しない。Goコード側にも `updated_at` への代入がない | **`updated_at` が作成時刻のまま更新されない** | `blog_users` / `blogs` / `blog_likes` |
+| `created_at` は `timestamptz`、`updated_at` は `timestamp`（TZなし）で型が不整合 | TZ差異による値のずれ | 同上 |
+
+- 該当は `work/backup.sql`（Supabase本番ダンプ）と `backend/testsupport/testdata/schema.sql`（IT/E2E用）の双方。
+- `blog_comments` は `updated_at` を持たない（更新機能がないため現状は問題にならない）。
+- スキーマ修正は影響範囲が異なるため別タスク（issue #117）として扱う。


### PR DESCRIPTION
## Summary
- `.claude/rules/database.md` を新規追加。ORM を使わず pgx を直叩きする構成に合わせ、監査列（`created_at` / `updated_at`）を **DB 側（`DEFAULT` + 共通トリガ関数 + `BEFORE UPDATE` トリガ）で自動設定する**方針、`timestamptz` 統一、スキーマ同期（`schema.sql` / `backup.sql` / docs）を明文化
- `CLAUDE.md` のルールテーブルに `database.md`（スコープ `backend/**`）を追記
- `docs/05-data-specification.md` に「7. 監査列方針」「7.1 現状との乖離（未対応）」を追加

## 背景

my-custom-skills の PR#123 で ORM テンプレート（GORM/JPA/Prisma 等）に監査列の自動化ルールが追加されたが、本プロジェクトは ORM 非使用のため適用できない。同等の保証を Postgres 側で担保するルールとして起こしたもの。

## 調査で判明した実バグ（本 PR では未修正）

- `updated_at` を更新する `BEFORE UPDATE` トリガが存在せず、Go 側にも代入がない（grep 0 件）→ **`updated_at` が作成時刻のまま固定される**
- `created_at` は `timestamptz`、`updated_at` は `timestamp`（TZ なし）で型が不整合

スキーマ修正は影響範囲が異なるため #117 に切り出し、本 PR ではドキュメントに既知の乖離として明記するに留めている。

## ドキュメント更新（documentation.md 影響マップ）

- ルール追加 → `CLAUDE.md` を更新済み。`readme.md` はルール一覧を持たず `.claude/rules/` へのリンクのみのため更新不要
- DB スキーマ方針 → `docs/05-data-specification.md` を更新済み

## Test plan
- [ ] `.claude/rules/database.md` の方針（DB 側自動化・`timestamptz` 統一）に合意できるか
- [ ] `CLAUDE.md` のルールテーブルの記載・スコープ（`backend/**`）が妥当か
- [ ] `docs/05-data-specification.md` の「7.1 現状との乖離」の内容が実態と一致しているか
- [ ] スキーマ修正を #117 として分離した判断が妥当か

コード変更を含まないためテスト追加なし（#117 で IT ケースを追加予定）。

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)